### PR TITLE
fix: credentials of old API was always checked

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,6 +4,7 @@ dotenv.config({ path: '.env.email_whitelist' })
 
 const config = {}
 
+config.NODE_ENV = process.env.NODE_ENV || "production"
 config.PORT = process.env.PORT || 8080
 config.PROTOCOL = process.env.PROTOCOL || "https"
 

--- a/config.js
+++ b/config.js
@@ -46,21 +46,29 @@ if (isPresent('EMAIL_WHITELIST')) {
   config.EMAIL_WHITELIST = [/.*/]
 }
 
-if (!isPresent('OVH_APP_KEY') || !isPresent('OVH_APP_SECRET') || !isPresent('OVH_CONSUMER_KEY') || !isPresent('OVH_ACCOUNT_NUMBER')) {
-  throw new Error('OVH is not set correctly')
-}
-config.OVH_APP_KEY = process.env.OVH_APP_KEY
-config.OVH_APP_SECRET = process.env.OVH_APP_SECRET
-config.OVH_CONSUMER_KEY = process.env.OVH_CONSUMER_KEY
-config.OVH_ACCOUNT_NUMBER = process.env.OVH_ACCOUNT_NUMBER
+config.USE_OVH_ROOM_API = process.env.USE_OVH_ROOM_API === 'true' || false
 
-config.USE_OVH_ROOM_API = (process.env.USE_OVH_ROOM_API === 'true') || false
-if (config.USE_OVH_ROOM_API) {
-  if (!isPresent('OVH_ROOM_APP_KEY') ||
+if (!config.USE_OVH_ROOM_API) {
+  if (
+    !isPresent('OVH_APP_KEY') ||
+    !isPresent('OVH_APP_SECRET') ||
+    !isPresent('OVH_CONSUMER_KEY') ||
+    !isPresent('OVH_ACCOUNT_NUMBER')
+  ) {
+    throw new Error('OVH legacy API is not set correctly')
+  }
+  config.OVH_APP_KEY = process.env.OVH_APP_KEY
+  config.OVH_APP_SECRET = process.env.OVH_APP_SECRET
+  config.OVH_CONSUMER_KEY = process.env.OVH_CONSUMER_KEY
+  config.OVH_ACCOUNT_NUMBER = process.env.OVH_ACCOUNT_NUMBER
+} else {
+  if (
+    !isPresent('OVH_ROOM_APP_KEY') ||
     !isPresent('OVH_ROOM_APP_SECRET') ||
     !isPresent('OVH_ROOM_CONSUMER_KEY') ||
     !isPresent('OVH_ROOM_ACCOUNT_NUMBER') ||
-    !isPresent('OVH_ROOM_PHONE_NUMBER')) {
+    !isPresent('OVH_ROOM_PHONE_NUMBER')
+  ) {
     throw new Error('OVH Rooms API is not set up correctly')
   }
   config.OVH_ROOM_APP_KEY = process.env.OVH_ROOM_APP_KEY
@@ -69,7 +77,6 @@ if (config.USE_OVH_ROOM_API) {
   config.OVH_ROOM_ACCOUNT_NUMBER = process.env.OVH_ROOM_ACCOUNT_NUMBER
   config.OVH_ROOM_PHONE_NUMBER = process.env.OVH_ROOM_PHONE_NUMBER
 }
-
 
 if (!isPresent('DATABASE_URL')) {
   throw new Error('Env vars DATABASE_URL should be set')

--- a/index.js
+++ b/index.js
@@ -15,8 +15,26 @@ const sendValidationEmailController = require('./controllers/sendValidationEmail
 const stats = require('./lib/stats')
 const urls = require('./urls')
 
-console.debug('Found config : ')
-console.dir(config)
+function obfuscate({config, secretKeys}) {
+  const res = {...config}
+  for (let key of secretKeys) {
+    res[key] = "·····"
+  }
+  return res
+}
+
+const secretKeys = [
+  "MAIL_PASS",
+  "OVH_ROOM_APP_KEY",
+  "OVH_ROOM_APP_SECRET",
+  "OVH_ROOM_CONSUMER_KEY",
+  "DATABASE_URL",
+  "SECRET",
+];
+
+const debugConfig = config.NODE_ENV === "development" ? config : obfuscate({config, secretKeys})
+
+console.dir({config: debugConfig})
 
 const app = express()
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,9 @@ const sendValidationEmailController = require('./controllers/sendValidationEmail
 const stats = require('./lib/stats')
 const urls = require('./urls')
 
+console.debug('Found config : ')
+console.dir(config)
+
 const app = express()
 
 app.set('view engine', 'ejs')

--- a/index.js
+++ b/index.js
@@ -15,26 +15,9 @@ const sendValidationEmailController = require('./controllers/sendValidationEmail
 const stats = require('./lib/stats')
 const urls = require('./urls')
 
-function obfuscate({config, secretKeys}) {
-  const res = {...config}
-  for (let key of secretKeys) {
-    res[key] = "·····"
-  }
-  return res
+if (config.NODE_ENV === "development") {
+  console.dir({ config });
 }
-
-const secretKeys = [
-  "MAIL_PASS",
-  "OVH_ROOM_APP_KEY",
-  "OVH_ROOM_APP_SECRET",
-  "OVH_ROOM_CONSUMER_KEY",
-  "DATABASE_URL",
-  "SECRET",
-];
-
-const debugConfig = config.NODE_ENV === "development" ? config : obfuscate({config, secretKeys})
-
-console.dir({config: debugConfig})
 
 const app = express()
 

--- a/lib/conferences.js
+++ b/lib/conferences.js
@@ -3,14 +3,17 @@ const db = require('../lib/db')
 
 const ovhLib = require('ovh')
 
-const ovh = ovhLib({
-  appKey: config.OVH_APP_KEY,
-  appSecret: config.OVH_APP_SECRET,
-  consumerKey: config.OVH_CONSUMER_KEY,
-})
-
+let ovh = null
 let ovhRooms = null
-if (config.USE_OVH_ROOM_API) {
+
+// If we're using the legacy OVH API
+if (!config.USE_OVH_ROOM_API) {
+  ovh = ovhLib({
+    appKey: config.OVH_APP_KEY,
+    appSecret: config.OVH_APP_SECRET,
+    consumerKey: config.OVH_CONSUMER_KEY,
+  })
+} else {
   ovhRooms = ovhLib({
     appKey: config.OVH_ROOM_APP_KEY,
     appSecret: config.OVH_ROOM_APP_SECRET,


### PR DESCRIPTION
- Gestion pour que les tokens de l'ancienne API ne soit pas nécessaire, si l'on utilise la nouvelle API OVH (room).
- Dans index, j'ai mis l'affichage de la config au démarrage. Je pense que c'est pratique mais à voir en terme de sécurité



