### PR TITLE
fix: use user timezone for conference expiration date

### DIFF
--- a/controllers/createConfController.js
+++ b/controllers/createConfController.js
@@ -27,7 +27,6 @@ const createConfWithDay = async (email, conferenceDay, userTimezoneOffset) => {
   try {
     console.log(`Création d'un numéro de conférence pour ${format.hashForLogs(email)} pour le ${conferenceDay}`)
 
-    // todo test with userTimezoneOffset = 0
     const timestampUTC = Date.parse(`${conferenceDay} 23:59:59 GMT`)
     const timestampZoned = timestampUTC + userTimezoneOffset * 60 * 1000
     const freeAt = new Date(timestampZoned)

--- a/controllers/createConfController.js
+++ b/controllers/createConfController.js
@@ -27,6 +27,7 @@ const createConfWithDay = async (email, conferenceDay, userTimezoneOffset) => {
   try {
     console.log(`Création d'un numéro de conférence pour ${format.hashForLogs(email)} pour le ${conferenceDay}`)
 
+    // todo test with userTimezoneOffset = 0
     const timestampUTC = Date.parse(`${conferenceDay} 23:59:59 GMT`)
     const timestampZoned = timestampUTC + userTimezoneOffset * 60 * 1000
     const freeAt = new Date(timestampZoned)
@@ -46,9 +47,6 @@ const createConfWithDay = async (email, conferenceDay, userTimezoneOffset) => {
 module.exports.createConf = async (req, res) => {
   const token = req.query.token
 
-  const userTimezoneOffset = req.query.timezoneOffset
-  console.log('Got timezoneOffset from query params', userTimezoneOffset) // todo remove log
-
   const tokensData = await db.getToken(token)
   const isTokenValid = tokensData.length === 1
 
@@ -61,6 +59,8 @@ module.exports.createConf = async (req, res) => {
   const email = tokenData.email
   const durationInMinutes = tokenData.durationInMinutes
   const conferenceDay = tokenData.conferenceDay
+  const userTimezoneOffset = tokenData.userTimezoneOffset
+  console.log('Got timezoneOffset from query params', userTimezoneOffset) // todo remove log
 
   if (!conferenceDay && !durationInMinutes) {
     console.error('Login token contained no conferenceDay and no durationInMinutes. Cannot create conference.')

--- a/controllers/sendValidationEmailController.js
+++ b/controllers/sendValidationEmailController.js
@@ -31,6 +31,12 @@ const generateToken = () => {
 }
 
 module.exports.sendValidationEmail = async (req, res) => {
+  // todo test the whole thing works with a timezone that is not the same as the server.
+  // todo test the whole thing works with a negative timezone (positive timezoneOffset).
+  const userTimezoneOffset = req.body.timezoneOffset
+  console.log('got timezoneOffset from form', userTimezoneOffset) // todo remove log
+  // todo should we save the timezone offset in db instead ?
+
   const email = req.body.email
   const conferenceDurationInMinutes = req.body.durationInMinutes
   const conferenceDayString = req.body.day
@@ -59,7 +65,7 @@ module.exports.sendValidationEmail = async (req, res) => {
     await db.insertToken(email, token, tokenExpirationDate, conferenceDurationInMinutes, conferenceDayString)
     console.log(`Login token créé pour ${format.hashForLogs(email)}, il expire à ${tokenExpirationDate}`)
 
-    const validationUrl = `${config.PROTOCOL}://${req.get('host')}${urls.createConf}?token=${encodeURIComponent(token)}`
+    const validationUrl = `${config.PROTOCOL}://${req.get('host')}${urls.createConf}?token=${encodeURIComponent(token)}&timezoneOffset=${userTimezoneOffset}`
     await emailer.sendEmailValidationEmail(email, token, tokenExpirationDate, validationUrl)
 
     res.redirect(url.format({

--- a/controllers/sendValidationEmailController.js
+++ b/controllers/sendValidationEmailController.js
@@ -63,7 +63,7 @@ module.exports.sendValidationEmail = async (req, res) => {
     console.log(`Login token créé pour ${format.hashForLogs(email)}, il expire à ${tokenExpirationDate}`)
 
     const validationUrl = `${config.PROTOCOL}://${req.get('host')}${urls.createConf}?token=${encodeURIComponent(token)}`
-    await emailer.sendEmailValidationEmail(email, token, tokenExpirationDate, validationUrl)
+    await emailer.sendEmailValidationEmail(email, tokenExpirationDate, validationUrl)
 
     res.redirect(url.format({
       pathname: urls.validationEmailSent,

--- a/controllers/sendValidationEmailController.js
+++ b/controllers/sendValidationEmailController.js
@@ -33,7 +33,6 @@ const generateToken = () => {
 module.exports.sendValidationEmail = async (req, res) => {
   const userTimezoneOffset = req.body.timezoneOffset
   console.log('got timezoneOffset from form', userTimezoneOffset) // todo remove log
-  // todo should we save the timezone offset in db instead ?
 
   const email = req.body.email
   const conferenceDurationInMinutes = req.body.durationInMinutes
@@ -60,10 +59,10 @@ module.exports.sendValidationEmail = async (req, res) => {
   tokenExpirationDate.setMinutes(tokenExpirationDate.getMinutes() + config.TOKEN_DURATION_IN_MINUTES)
 
   try {
-    await db.insertToken(email, token, tokenExpirationDate, conferenceDurationInMinutes, conferenceDayString)
+    await db.insertToken(email, token, tokenExpirationDate, conferenceDurationInMinutes, conferenceDayString, userTimezoneOffset)
     console.log(`Login token créé pour ${format.hashForLogs(email)}, il expire à ${tokenExpirationDate}`)
 
-    const validationUrl = `${config.PROTOCOL}://${req.get('host')}${urls.createConf}?token=${encodeURIComponent(token)}&timezoneOffset=${userTimezoneOffset}`
+    const validationUrl = `${config.PROTOCOL}://${req.get('host')}${urls.createConf}?token=${encodeURIComponent(token)}`
     await emailer.sendEmailValidationEmail(email, token, tokenExpirationDate, validationUrl)
 
     res.redirect(url.format({

--- a/controllers/sendValidationEmailController.js
+++ b/controllers/sendValidationEmailController.js
@@ -31,8 +31,6 @@ const generateToken = () => {
 }
 
 module.exports.sendValidationEmail = async (req, res) => {
-  // todo test the whole thing works with a timezone that is not the same as the server.
-  // todo test the whole thing works with a negative timezone (positive timezoneOffset).
   const userTimezoneOffset = req.body.timezoneOffset
   console.log('got timezoneOffset from form', userTimezoneOffset) // todo remove log
   // todo should we save the timezone offset in db instead ?

--- a/controllers/sendValidationEmailController.js
+++ b/controllers/sendValidationEmailController.js
@@ -31,7 +31,7 @@ const generateToken = () => {
 }
 
 module.exports.sendValidationEmail = async (req, res) => {
-  const userTimezoneOffset = req.body.timezoneOffset
+  const userTimezoneOffset = req.body.userTimezoneOffset
   console.log('got timezoneOffset from form', userTimezoneOffset) // todo remove log
 
   const email = req.body.email

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,4 +1,5 @@
 const config = require('../config');
+const format = require('../lib/format')
 
 const knex = require('knex')({
     client: 'pg',
@@ -198,11 +199,20 @@ module.exports.insertToken = async (email, token, tokenExpirationDate, conferenc
 
 module.exports.getToken = async (token) => {
     try {
-       return await knex('loginTokens').select()
-        .where({ token: token })
-        .andWhere('expiresAt', '>', new Date())
-        .del()
-        .returning("*")
+        const tokens = await knex('loginTokens').select()
+            .where({ token: token })
+            .andWhere('expiresAt', '>', new Date())
+            .del()
+            .returning("*")
+        // Format the conferenceDays to be YYYY-MM-DD strings, rather than full Date objects
+        // todo test the insertToken + getToken keeps the dateString
+        tokens.forEach(token => {
+            if (token.conferenceDay) {
+                const dayString = format.formatStandardDate(token.conferenceDay)
+                token.conferenceDay = dayString
+            }
+       })
+       return tokens
     } catch (err) {
       console.error(`Impossible de récupérer le token`, err)
       throw new Error('Impossible de récupérer le token')

--- a/lib/db.js
+++ b/lib/db.js
@@ -205,7 +205,6 @@ module.exports.getToken = async (token) => {
             .del()
             .returning("*")
         // Format the conferenceDays to be YYYY-MM-DD strings, rather than full Date objects
-        // todo test the insertToken + getToken keeps the dateString
         tokens.forEach(token => {
             if (token.conferenceDay) {
                 const dayString = format.formatStandardDate(token.conferenceDay)

--- a/lib/db.js
+++ b/lib/db.js
@@ -182,7 +182,7 @@ module.exports.cancelConference = async (id) => {
 }
 
 // conferenceDayString format : YYY-MM-DD
-module.exports.insertToken = async (email, token, tokenExpirationDate, conferenceDurationInMinutes, conferenceDayString) => {
+module.exports.insertToken = async (email, token, tokenExpirationDate, conferenceDurationInMinutes, conferenceDayString, userTimezoneOffset = -1) => {
     try {
       return await knex('loginTokens').insert({
         token,
@@ -190,6 +190,7 @@ module.exports.insertToken = async (email, token, tokenExpirationDate, conferenc
         durationInMinutes: conferenceDurationInMinutes,
         expiresAt: tokenExpirationDate,
         conferenceDay: conferenceDayString,
+        userTimezoneOffset,
       });
     } catch (err) {
       console.error(`Erreur de sauvegarde du token`, err)

--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -80,7 +80,6 @@ module.exports.sendConfCreatedEmail = async function(toEmail, phoneNumber, pin, 
   if (conferenceDay) {
     expirationInfo = `Ce numéro de conférence sera actif toute la journée du ${format.formatFrenchDate(new Date(conferenceDay))} et expirera à minuit.`
   } else {
-    // todo expiration date formatted in GMT+1 is probably weird if you are not in GMT+1
     expirationInfo = `Ce numéro de conférence est actif pendant ${format.formatMinutesInHours(durationInMinutes)}. Il expirera ${format.formatFrenchDateTime(freeAt)}.`
   }
 

--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -64,7 +64,6 @@ module.exports.sendEmailValidationEmail = async function(toEmail, token, tokenEx
 }
 
 // todo all times in emails should be local time zone at this point.
-// todo check what happens when there is no conferenceDay (does the presence check work ?)
 module.exports.sendConfCreatedEmail = async function(toEmail, phoneNumber, pin, durationInMinutes, conferenceDay, freeAt, confUrl, pollUrl) {
   let pollHtml = ''
   if (pollUrl) {

--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -63,6 +63,7 @@ module.exports.sendEmailValidationEmail = async function(toEmail, token, tokenEx
   }
 }
 
+// todo all times in emails should be local time zone at this point.
 // todo check what happens when there is no conferenceDay (does the presence check work ?)
 module.exports.sendConfCreatedEmail = async function(toEmail, phoneNumber, pin, durationInMinutes, conferenceDay, freeAt, confUrl, pollUrl) {
   let pollHtml = ''

--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -39,7 +39,7 @@ const sendMail = async function (fromEmail, toEmail, subject, html) {
   });
 }
 
-module.exports.sendEmailValidationEmail = async function(toEmail, token, tokenExpirationDate, url) {
+module.exports.sendEmailValidationEmail = async function(toEmail, tokenExpirationDate, url) {
   const html = `
   <p>Bonjour,</p>
   <p></p>

--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -63,6 +63,7 @@ module.exports.sendEmailValidationEmail = async function(toEmail, token, tokenEx
   }
 }
 
+// todo check what happens when there is no conferenceDay (does the presence check work ?)
 module.exports.sendConfCreatedEmail = async function(toEmail, phoneNumber, pin, durationInMinutes, conferenceDay, freeAt, confUrl, pollUrl) {
   let pollHtml = ''
   if (pollUrl) {
@@ -77,8 +78,9 @@ module.exports.sendConfCreatedEmail = async function(toEmail, phoneNumber, pin, 
 
   let expirationInfo = ''
   if (conferenceDay) {
-    expirationInfo = `Ce numéro de conférence sera actif toute la journée du ${format.formatFrenchDate(conferenceDay)} et expirera à minuit.`
+    expirationInfo = `Ce numéro de conférence sera actif toute la journée du ${format.formatFrenchDate(new Date(conferenceDay))} et expirera à minuit.`
   } else {
+    // todo expiration date formatted in GMT+1 is probably weird if you are not in GMT+1
     expirationInfo = `Ce numéro de conférence est actif pendant ${format.formatMinutesInHours(durationInMinutes)}. Il expirera ${format.formatFrenchDateTime(freeAt)}.`
   }
 
@@ -107,7 +109,7 @@ module.exports.sendConfCreatedEmail = async function(toEmail, phoneNumber, pin, 
   <div>Bonjour,</div>
 
   <div class="paragraph">
-    <div>Votre conférence téléphonique ${conferenceDay ? `du ${format.formatFrenchDate(conferenceDay)} ` : '' }est réservée. Elle pourra accueillir jusqu'à 50 personnes.</div>
+    <div>Votre conférence téléphonique ${conferenceDay ? `du ${format.formatFrenchDate(new Date(conferenceDay))} ` : '' }est réservée. Elle pourra accueillir jusqu'à 50 personnes.</div>
     <div>Pour vous y connecter : <div>
     <ul>
       <li>appelez le <a href="tel:${phoneNumber},,${pin}"><strong>${format.formatFrenchPhoneNumber(phoneNumber)}</strong></a> (numéro non surtaxé) sur votre téléphone fixe ou mobile</li>
@@ -132,7 +134,7 @@ module.exports.sendConfCreatedEmail = async function(toEmail, phoneNumber, pin, 
     return await sendMail(
       config.MAIL_SENDER_EMAIL,
       toEmail,
-      `Votre conférence téléphonique ${conferenceDay ? `du ${format.formatFrenchDate(conferenceDay)} ` : '' }est réservée`,
+      `Votre conférence téléphonique ${conferenceDay ? `du ${format.formatFrenchDate(new Date(conferenceDay))} ` : '' }est réservée`,
       html,
     )
   } catch (err) {

--- a/lib/format.js
+++ b/lib/format.js
@@ -19,8 +19,7 @@ const dateTimeFormatter = new Intl.DateTimeFormat('fr-FR', {
   month: 'long', day: 'numeric',
   hour: 'numeric', minute: 'numeric',
 })
-const GMTString = date => {
-  const offset = date.getTimezoneOffset()
+const GMTString = offset => {
   const GMT = (-offset/60)
   if (GMT === 0) {
     return 'GMT'
@@ -33,8 +32,9 @@ const GMTString = date => {
   }
 }
 module.exports.formatFrenchDateTime = date => {
-  return dateTimeFormatter.format(date) + ' ' + GMTString(date)
+  return dateTimeFormatter.format(date) + ' ' + GMTString(date.getTimezoneOffset())
 }
+module.exports.GMTString = GMTString
 
 const dateFormatter = new Intl.DateTimeFormat('fr-FR', {
   weekday: 'long', year: 'numeric',

--- a/lib/format.js
+++ b/lib/format.js
@@ -31,10 +31,10 @@ const GMTString = offset => {
     return 'GMT' + GMT
   }
 }
-module.exports.formatFrenchDateTime = date => {
-  return dateTimeFormatter.format(date) + ' ' + GMTString(date.getTimezoneOffset())
+const serverTimezoneOffset = new Date().getTimezoneOffset()
+module.exports.formatFrenchDateTime = (date) => {
+  return dateTimeFormatter.format(date) + ' ' + GMTString(serverTimezoneOffset)
 }
-module.exports.GMTString = GMTString
 
 const dateFormatter = new Intl.DateTimeFormat('fr-FR', {
   weekday: 'long', year: 'numeric',

--- a/migrations/20201204180832_add-userTimezoneOffset-to-loginTokens.js
+++ b/migrations/20201204180832_add-userTimezoneOffset-to-loginTokens.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.table('loginTokens', function (table) {
+    table.integer('userTimezoneOffset').defaultTo(-1) // default : Paris winter time
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.table('loginTokens', function (table) {
+    table.dropColumn('userTimezoneOffset')
+  })
+}

--- a/test/dbTest.js
+++ b/test/dbTest.js
@@ -1,0 +1,30 @@
+const chai = require('chai')
+const crypto = require('crypto') // todo move this to db ? export this from its home module ?
+const db = require('../lib/db')
+
+describe('db', function() {
+  describe('loginTokens table', function() {
+    it('should return the same dateString for conferenceDay that was inserted', async function() {
+      const conferenceDayString = '2020-12-04'
+      const token = crypto.randomBytes(256).toString("base64")
+
+      const tokenExpirationDate = new Date()
+      tokenExpirationDate.setMinutes(tokenExpirationDate.getMinutes() + 60)
+
+      await db.insertToken(
+        'hello@blah.com',
+        token,
+        tokenExpirationDate,
+        undefined, // conferenceDurationInMinutes
+        conferenceDayString,
+      )
+
+      const fetchedTokens = await db.getToken(token)
+
+      chai.assert.equal(fetchedTokens.length, 1)
+      chai.assert.equal(fetchedTokens[0].conferenceDay, conferenceDayString)
+
+      return Promise.resolve() // needed for async test
+    })
+  })
+})

--- a/test/formatTest.js
+++ b/test/formatTest.js
@@ -1,0 +1,12 @@
+const chai = require('chai')
+const format = require('../lib/format')
+
+describe('format', function() {
+  it('should display times in default server timezone', function(done) {
+    const date = new Date('2020-12-04 18:37:00')
+    const formattedDateTime = format.formatFrenchDateTime(date)
+    console.log(formattedDateTime)
+    chai.assert.include(formattedDateTime, '18:37', 'has the right time')
+    done()
+  })
+})

--- a/views/landing.ejs
+++ b/views/landing.ejs
@@ -53,6 +53,10 @@
                   </select>
                 </div>
               <% } %>
+              <div>
+                hidden input!! timezoneOffset todo hide the input
+                <input type="number" id="timezoneOffset" name="timezoneOffset" required>
+              </div>
               <div class="rf-input-group">
                 <button type="submit" class="rf-btn" title="Réserver ma conférence">Réserver ma conférence</button>
               </div>
@@ -140,4 +144,8 @@
   </div>
 </div>
 
+<script>
+  // Fill in the hidden input with the user's timezoneOffset
+  document.getElementById('timezoneOffset').value = new Date().getTimezoneOffset()
+</script>
 <%- include('partials/footer') -%>

--- a/views/landing.ejs
+++ b/views/landing.ejs
@@ -54,8 +54,8 @@
                 </div>
               <% } %>
               <div>
-                hidden input!! timezoneOffset todo hide the input
-                <input type="number" id="timezoneOffset" name="timezoneOffset" required>
+                hidden input!! userTimezoneOffset todo hide the input
+                <input type="number" id="userTimezoneOffset" name="userTimezoneOffset" required>
               </div>
               <div class="rf-input-group">
                 <button type="submit" class="rf-btn" title="Réserver ma conférence">Réserver ma conférence</button>
@@ -146,6 +146,6 @@
 
 <script>
   // Fill in the hidden input with the user's timezoneOffset
-  document.getElementById('timezoneOffset').value = new Date().getTimezoneOffset()
+  document.getElementById('userTimezoneOffset').value = new Date().getTimezoneOffset()
 </script>
 <%- include('partials/footer') -%>


### PR DESCRIPTION
Up to now, we used server timezone everywhere (set to 'Europe/Paris' by default).
This means that conferences booked for a give day expired at 23:59, **Paris time**, on the given day. This could cut off a conference earlier than a user expected.

This PR gets the user timezoneOffset (e.g. for GMT+1, timezoneOffset is -60), stores it in the loginToken table, and uses it to set an expiration date in the right timezone.

Left for later : display all times in the user's timezone, in the interface and the emails. This is trickier than expected, and with current featureset (conferences booked for whole day) it's only used for logintoken expiration dates. I would rather push this fix to prod fast since it can cut off conferences for users.

