### PR TITLE
Email en minuscule avant le hash

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -33,25 +33,22 @@ const GMTString = offset => {
 }
 module.exports.GMTString = GMTString
 const serverTimezoneOffset = new Date().getTimezoneOffset()
-module.exports.formatFrenchDateTime = (date) => {
-  return dateTimeFormatter.format(date) + ' ' + GMTString(serverTimezoneOffset)
-}
+
+module.exports.formatFrenchDateTime = (date) => dateTimeFormatter.format(date) + ' ' + GMTString(serverTimezoneOffset)
 
 const dateFormatter = new Intl.DateTimeFormat('fr-FR', {
   weekday: 'long', year: 'numeric',
   month: 'long', day: 'numeric',
 })
-module.exports.formatFrenchDate = date => {
-  return dateFormatter.format(date)
-}
+
+module.exports.formatFrenchDate = date => dateFormatter.format(date)
+
 
 const shortDateFormatter = new Intl.DateTimeFormat('fr-FR', {
   month: 'numeric', day: 'numeric',
   hour: 'numeric', minute: 'numeric',
 })
-module.exports.formatShortFrenchDate = date => {
-  return shortDateFormatter.format(date)
-}
+module.exports.formatShortFrenchDate = date => shortDateFormatter.format(date)
 
 module.exports.formatStandardDate = date => {
   const year = date.getFullYear()
@@ -63,12 +60,9 @@ module.exports.formatStandardDate = date => {
 module.exports.formatMinutesInHours = minutes =>
   `${Math.floor(minutes/60)} heure${ minutes >= 120 ? 's' : ''}`
 
-module.exports.hashForLogs = (object) => {
-  const hash = crypto.createHmac('sha256', config.SECRET)
-    .update(object.toLowerCase())
-    .digest('hex')
-  return hash
-}
+module.exports.hashForLogs = (object = "") => crypto.createHmac('sha256', config.SECRET)
+  .update(object.toLowerCase())
+  .digest('hex')
 
 // Note : this function is imported in browser-side code, and needs to work in IE : use ";" and no "=>"
 module.exports.formatPin = function(pin) {

--- a/lib/format.js
+++ b/lib/format.js
@@ -65,7 +65,7 @@ module.exports.formatMinutesInHours = minutes =>
 
 module.exports.hashForLogs = (object) => {
   const hash = crypto.createHmac('sha256', config.SECRET)
-    .update(object)
+    .update(object.toLowerCase())
     .digest('hex')
   return hash
 }


### PR DESCRIPTION
ça permet de recalculer plus simplement le hash en cas de frappes différentes