### PR TITLE
feat: add memorystore to prevent memory leaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,9 @@ const bodyParser = require("body-parser")
 const express = require("express")
 const flash = require("connect-flash")
 const path = require("path")
+const cookieParser = require("cookie-parser")
 const session = require("express-session")
+const MemoryStore = require("memorystore")(session)
 
 const config = require("./config")
 const db = require("./lib/db")
@@ -29,10 +31,19 @@ app.use("/static", express.static("static"))
 app.use("/~", express.static(path.join(__dirname, "node_modules")))
 app.use(bodyParser.urlencoded({ extended: false }))
 
+app.use(cookieParser(config.secret))
 // Only used for Flash not safe for others purposes
 app.use(session({
-  secret: process.env.SECRET,
-  cookie: { maxAge: 300000, sameSite: "lax" }
+  secret: config.SECRET,
+  resave: false,
+  saveUninitialized: false, // "complying with laws that require permission before setting a cookie"
+  cookie: {
+    maxAge: 300000,
+    sameSite: "lax" // todo strict would be better for prod
+  },
+  store: new MemoryStore({
+    checkPeriod: 300000
+  })
 }))
 
 app.use(flash())

--- a/package-lock.json
+++ b/package-lock.json
@@ -1637,6 +1637,15 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
+    "cookie-parser": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
+      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
+      "requires": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6"
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -4929,6 +4938,39 @@
         "timers-ext": "^0.1.5"
       }
     },
+    "memorystore": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/memorystore/-/memorystore-1.6.4.tgz",
+      "integrity": "sha512-51j4kUedbqkWGby44hAhf5f/hj8GOvHoLX00/YHURBNxOMf5k8JbPuGfmeNpZEXhc3vrmfnFben4+rOOx3HjEQ==",
+      "requires": {
+        "debug": "^4.3.0",
+        "lru-cache": "^4.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
+      }
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -5857,6 +5899,11 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "chart.js": "^2.9.4",
     "connect-flash": "^0.1.1",
     "connect-session-knex": "^2.0.0",
+    "cookie-parser": "^1.4.5",
     "cron": "^1.8.2",
     "date-fns": "^2.16.1",
     "dotenv": "^8.2.0",
@@ -43,6 +44,7 @@
     "express-session": "^1.17.1",
     "intl": "^1.2.5",
     "knex": "^0.21.6",
+    "memorystore": "^1.6.4",
     "nodemailer": "^6.4.14",
     "ovh": "^2.0.3",
     "pg": "^8.4.2"


### PR DESCRIPTION
Add memoryStore (a js lib) to prevent the potential problem of memory leaks, since #107 .
Add cookie-parser to sign the cookie (same solution as secretariat).
