### PR TITLE
Add a config.HOSTNAME var to avoid host header attacks

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -35,7 +35,7 @@ OVH_ROOM_PHONE_NUMBER=CHANGE_ME
 # HTTP
 #PORT=8080
 # Hostname : the links sent in email will use this hostname. Default is http://localhost:$PORT
-HOSTNAME_WITH_PROTOCOL="https://myapp.com"
+#HOSTNAME_WITH_PROTOCOL="https://myapp.com"
 
 # If set, will display a "Give your opinion" link in the conf confirmation page and in the conf email.
 #POLL_URL=https://mypoll.com/455411

--- a/.env.sample
+++ b/.env.sample
@@ -34,7 +34,8 @@ OVH_ROOM_PHONE_NUMBER=CHANGE_ME
 
 # HTTP
 #PORT=8080
-PROTOCOL="http"
+# Hostname : the links sent in email will use this hostname. Default is http://localhost:$PORT
+HOSTNAME_WITH_PROTOCOL="https://myapp.com"
 
 # If set, will display a "Give your opinion" link in the conf confirmation page and in the conf email.
 #POLL_URL=https://mypoll.com/455411

--- a/app.json
+++ b/app.json
@@ -1,7 +1,0 @@
-{
-    "name": "secretariat",
-    "scripts": {
-      "postdeploy": "npm run migrate"
-    }
-}
-  

--- a/config.js
+++ b/config.js
@@ -6,7 +6,6 @@ const config = {}
 
 config.NODE_ENV = process.env.NODE_ENV || "production"
 config.PORT = process.env.PORT || 8080
-config.PROTOCOL = process.env.PROTOCOL || "https"
 
 const isPresent = varName => {
   if (varName in process.env && process.env[varName].trim() !== "") {
@@ -16,7 +15,8 @@ const isPresent = varName => {
 }
 
 config.APP_NAME = process.env.APP_NAME || "CoucouCollègues"
-config.HOSTNAME = process.env.HOSTNAME || `localhost:${config.PORT}`
+
+config.HOSTNAME_WITH_PROTOCOL = process.env.HOSTNAME_WITH_PROTOCOL || `http://localhost:${config.PORT}`
 
 if (!isPresent("MAIL_USER") || !isPresent("MAIL_PASS")) {
   throw new Error("Env vars MAIL_USER and MAIL_PASS should be set")

--- a/config.js
+++ b/config.js
@@ -4,7 +4,7 @@ dotenv.config({ path: ".env.email_whitelist" })
 
 const config = {}
 
-config.NODE_ENV = process.env.NODE_ENV || "production"
+config.NODE_ENV = process.env.NODE_ENV || "production"
 config.PORT = process.env.PORT || 8080
 config.PROTOCOL = process.env.PROTOCOL || "https"
 
@@ -16,7 +16,7 @@ const isPresent = varName => {
 }
 
 config.APP_NAME = process.env.APP_NAME || "CoucouCollègues"
-
+config.HOSTNAME = process.env.HOSTNAME || `localhost:${config.PORT}`
 
 if (!isPresent("MAIL_USER") || !isPresent("MAIL_PASS")) {
   throw new Error("Env vars MAIL_USER and MAIL_PASS should be set")

--- a/controllers/createConfController.js
+++ b/controllers/createConfController.js
@@ -73,7 +73,7 @@ module.exports.createConf = async (req, res) => {
     return res.redirect('/')
   }
 
-  const confUrl = `${config.PROTOCOL}://${req.get('host')}${urls.showConf.replace(":id", conference.id)}#${conference.pin}`
+  const confUrl = `${config.PROTOCOL}://${config.HOSTNAME}${urls.showConf.replace(":id", conference.id)}#${conference.pin}`
   try {
     await emailer.sendConfCreatedEmail(email, conference.phoneNumber, conference.pin, durationInMinutes, conferenceDay, conference.expiresAt, confUrl, config.POLL_URL, userTimezoneOffset)
 

--- a/controllers/createConfController.js
+++ b/controllers/createConfController.js
@@ -73,9 +73,8 @@ module.exports.createConf = async (req, res) => {
     return res.redirect('/')
   }
 
-  const confUrl = `${config.PROTOCOL}://${config.HOSTNAME}${urls.showConf.replace(":id", conference.id)}#${conference.pin}`
   try {
-    await emailer.sendConfCreatedEmail(email, conference.phoneNumber, conference.pin, durationInMinutes, conferenceDay, conference.expiresAt, confUrl, config.POLL_URL, userTimezoneOffset)
+    await emailer.sendConfCreatedEmail(email, conference.phoneNumber, conference.pin, durationInMinutes, conferenceDay, conference.expiresAt, config.POLL_URL, userTimezoneOffset)
 
     return res.redirect(urls.showConf.replace(":id", conference.id) + '#' + conference.pin)
   } catch (err) {

--- a/controllers/sendValidationEmailController.js
+++ b/controllers/sendValidationEmailController.js
@@ -61,7 +61,7 @@ module.exports.sendValidationEmail = async (req, res) => {
     await db.insertToken(email, token, tokenExpirationDate, conferenceDurationInMinutes, conferenceDayString, userTimezoneOffset)
     console.log(`Login token créé pour ${format.hashForLogs(email)}, il expire à ${tokenExpirationDate}`)
 
-    const validationUrl = `${config.PROTOCOL}://${req.get('host')}${urls.createConf}?token=${encodeURIComponent(token)}`
+    const validationUrl = `${config.PROTOCOL}://${config.HOSTNAME}${urls.createConf}?token=${encodeURIComponent(token)}`
     await emailer.sendEmailValidationEmail(email, tokenExpirationDate, validationUrl)
 
     res.redirect(url.format({

--- a/controllers/sendValidationEmailController.js
+++ b/controllers/sendValidationEmailController.js
@@ -61,7 +61,7 @@ module.exports.sendValidationEmail = async (req, res) => {
     await db.insertToken(email, token, tokenExpirationDate, conferenceDurationInMinutes, conferenceDayString, userTimezoneOffset)
     console.log(`Login token créé pour ${format.hashForLogs(email)}, il expire à ${tokenExpirationDate}`)
 
-    const validationUrl = `${config.PROTOCOL}://${config.HOSTNAME}${urls.createConf}?token=${encodeURIComponent(token)}`
+    const validationUrl = `${config.HOSTNAME_WITH_PROTOCOL}${urls.createConf}?token=${encodeURIComponent(token)}`
     await emailer.sendEmailValidationEmail(email, tokenExpirationDate, validationUrl)
 
     res.redirect(url.format({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
       MAIL_HOST: maildev
       MAIL_IGNORE_TLS: "true"
       MAIL_PORT: 25
-      PROTOCOL: "http"
       MAIL_SENDER_EMAIL: test@example.com
       SECRET: secret
       POLL_URL: https://github.com/betagouv/conferences/issues

--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -69,7 +69,6 @@ module.exports.sendConfCreatedEmail = async function(
     durationInMinutes,
     conferenceDay,
     freeAt,
-    confUrl,
     pollUrl,
     userTimezoneOffset = -60, // default : Paris winter time
   ) {

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "CANONICAL_HOST_URL": {
+      "generator": "url"
+    }
+  }
+}

--- a/scalingo.json
+++ b/scalingo.json
@@ -9,8 +9,11 @@
       "generator": "url",
       "template": "%URL%/admin"
     },
-    "MAYBE_APP": {
-      "template": "%APP%"
+    "AAA_APP": {
+      "template": "%APP%-coucou"
+    },
+    "AAA_PARENT": {
+      "template": "%PARENT_APP%-coucou"
     }
   }
 }

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,6 +1,6 @@
 {
   "env": {
-    "CANONICAL_HOST_URL": {
+    "HOSTNAME": {
       "generator": "url"
     }
   }

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,19 +1,8 @@
 {
   "env": {
-    "HOSTNAME": {
+    "HOSTNAME_WITH_PROTOCOL": {
       "description": "Url with protocol, ex: https://my-scalingo-app-pr36.scalingo.io",
       "generator": "url"
-    },
-    "ADMIN_URL": {
-      "description": "Admin URL of the application",
-      "generator": "url",
-      "template": "%URL%/admin"
-    },
-    "AAA_APP": {
-      "template": "%APP%-coucou"
-    },
-    "AAA_PARENT": {
-      "template": "%PARENT_APP%-coucou"
     }
   }
 }

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,7 +1,16 @@
 {
   "env": {
     "HOSTNAME": {
+      "description": "Url with protocol, ex: https://my-scalingo-app-pr36.scalingo.io",
       "generator": "url"
+    },
+    "ADMIN_URL": {
+      "description": "Admin URL of the application",
+      "generator": "url",
+      "template": "%URL%/admin"
+    },
+    "MAYBE_APP": {
+      "template": "%APP%"
     }
   }
 }

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,8 +1,12 @@
 {
+  "name": "AudioConf",
   "env": {
     "HOSTNAME_WITH_PROTOCOL": {
       "description": "Url with protocol, ex: https://my-scalingo-app-pr36.scalingo.io",
       "generator": "url"
     }
+  },
+  "scripts": {
+    "postdeploy": "npm run migrate"
   }
 }


### PR DESCRIPTION
Add a HOSTNAME_WITH_PROTOCOL config var, that will be used to send and display links, instead of using the host header from the request.
This avoids host header poisoning attacks (detected by CodeQL : https://github.com/betagouv/audioconf/security/code-scanning/11?query=ref%3Arefs%2Fheads%2Fmain)

By default, HOSTNAME_WITH_PROTOCOL is http://localhost:${PORT}

We use HOSTNAME_WITH_PROTOCOL (instead of HOSTNAME and PROTOCOL) separately, because that's the var that scalingo review apps have. So we use it for all scalingo apps for simplicity.

This PR adds a scalingo.json file (with which we configure the HOSTNAME_WITH_PROTOCOL vars). When this file is present, the app.json file is ignored, so this PR removes it.

 - [x] add HOSTNAME_WITH_PROTOCOL var to prod instance
 - [x] add HOSTNAME_WITH_PROTOCOL var to staging instance
 - [x] how to get hostname in review apps ?
 - [x] update docker files to avoid breaking docker installs