### PR TITLE
Job de stats toutes les minutes

### DIFF
--- a/cron.js
+++ b/cron.js
@@ -7,7 +7,7 @@ const config = require("./config")
 
 const jobs = [
   {
-    cronTime: "*/2 * * * *", // every two minutes
+    cronTime: "* * * * *", // every minutes
     onTick: computeStats,
     start: true,
     timeZone: "Europe/Paris",


### PR DESCRIPTION
Le job est moins couteux, on peut le lancer tous les minutes.
Les pics d'usages sont moins importants en janvier qu'en décembre pourtant il y a plus de conférences de faites, c'est pour voir si avec une plus grosse fréquence, on voit mieux les pics.