### PR TITLE
Add link to AudioConf in emails

### DIFF
--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -124,7 +124,7 @@ module.exports.sendConfCreatedEmail = async function(
   <hr />
   ${pollHtml}
   <div>
-    Vous voulez créer votre propre conférence ? C'est en self-service, allez sur
+    Créez votre propre conférence téléphonique, en toute autonomie, en allant sur
     <a href="${config.HOSTNAME_WITH_PROTOCOL}">${config.HOSTNAME_WITH_PROTOCOL}</a>
   </div>
   `

--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -74,7 +74,7 @@ module.exports.sendConfCreatedEmail = async function(
   ) {
   let pollHtml = ""
   if (pollUrl) {
-    pollHtml = `<hr />
+    pollHtml = `
     <div class="paragraph">
       <div>
         Vous avez une remarque ou une suggestion ?
@@ -121,8 +121,12 @@ module.exports.sendConfCreatedEmail = async function(
     Bonne journée avec <a href="${config.HOSTNAME_WITH_PROTOCOL}">${config.APP_NAME}</a> !
   </div>
 
+  <hr />
   ${pollHtml}
-
+  <div>
+    Vous voulez créer votre propre conférence ? C'est en self-service, allez sur
+    <a href="${config.HOSTNAME_WITH_PROTOCOL}">${config.HOSTNAME_WITH_PROTOCOL}</a>
+  </div>
   `
 
   try {

--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -47,7 +47,7 @@ module.exports.sendEmailValidationEmail = async function(toEmail, tokenExpiratio
   <p></p>
   <p>Ce lien est actif pendant ${config.TOKEN_DURATION_IN_MINUTES} minutes. Il expirera ${format.formatFrenchDateTime(tokenExpirationDate)}.</p>
   <p></p>
-  <p>Bonne journée avec <a href="${config.HOSTNAME_WITH_PROTOCOL}">${config.APP_NAME}</a> !</p>`
+  <p>Bonne journée avec ${config.APP_NAME} !</p>`
 
   try {
     return await sendMail(
@@ -125,7 +125,7 @@ module.exports.sendConfCreatedEmail = async function(
   ${pollHtml}
   <div>
     Créez votre propre conférence téléphonique, en toute autonomie, en allant sur
-    <a href="${config.HOSTNAME_WITH_PROTOCOL}">${config.HOSTNAME_WITH_PROTOCOL}</a>
+    <a href="${config.HOSTNAME_WITH_PROTOCOL}">${config.APP_NAME}</a>
   </div>
   `
 

--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -47,7 +47,7 @@ module.exports.sendEmailValidationEmail = async function(toEmail, tokenExpiratio
   <p></p>
   <p>Ce lien est actif pendant ${config.TOKEN_DURATION_IN_MINUTES} minutes. Il expirera ${format.formatFrenchDateTime(tokenExpirationDate)}.</p>
   <p></p>
-  <p>Bonne journée avec ${config.APP_NAME} !</p>`
+  <p>Bonne journée avec <a href="${config.HOSTNAME_WITH_PROTOCOL}">${config.APP_NAME}</a> !</p>`
 
   try {
     return await sendMail(
@@ -100,7 +100,12 @@ module.exports.sendConfCreatedEmail = async function(
   <div>Bonjour,</div>
 
   <div class="paragraph">
-    <div>Votre conférence téléphonique ${conferenceDay ? `du ${format.formatFrenchDate(new Date(conferenceDay))} ` : "" }est réservée. Elle pourra accueillir jusqu'à 50 personnes.</div>
+    <div>
+      Votre conférence téléphonique
+      <a href="${config.HOSTNAME_WITH_PROTOCOL}">${config.APP_NAME}</a>
+      ${conferenceDay ? `du ${format.formatFrenchDate(new Date(conferenceDay))} ` : "" }
+      est réservée. Elle pourra accueillir jusqu'à 50 personnes.
+    </div>
     <div>Pour vous y connecter : <div>
     <ul>
       <li>appelez le <a href="tel:${phoneNumber},,${pin}"><strong>${format.formatFrenchPhoneNumber(phoneNumber)}</strong></a> (numéro non surtaxé) sur votre téléphone fixe ou mobile</li>
@@ -113,7 +118,7 @@ module.exports.sendConfCreatedEmail = async function(
   </div>
 
   <div class="paragraph">
-    Bonne journée avec ${config.APP_NAME} !
+    Bonne journée avec <a href="${config.HOSTNAME_WITH_PROTOCOL}">${config.APP_NAME}</a> !
   </div>
 
   ${pollHtml}


### PR DESCRIPTION
Plusieurs utilisateurs ont envoyé un mail pour demander la création d'une conf, sans comprendre que c'était self-service.
C'est probable qu'ils n'étaient pas allés voir le site (sinon ils auraient compris) donc on suppose qu'ils ont été participants et veulent essayer d'en organiser. 

Comme le mail de confirmation est fait pour etre forwardé aux participants, cette PR ajoute des instructions pour créer sa propre conf dans le mail (avec des liens vers AudioConf.