### PR TITLE
Add bounds to callsStats query

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -59,6 +59,3 @@ AFTER_MEETING_SURVEY_URL=https://startupdetat.typeform.com/to/CQhQfpVU
 # FEATURE_JOB_ANONYMIZE_EMAILS=true
 # To fetch the stats from past calls from OVH
 # FEATURE_JOB_CALLS_STATS=true
-
-# Make some jobs running with no DB persistence
-#JOB_DRY_RUN=false

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Points d'API nécessaires pour les fonctionalités actuelles, pour l'API Rooms :
 POST /telephony/${OVH_ROOM_ACCOUNT_NUMBER}/conference/${OVH_ROOM_PHONE_NUMBER}/rooms
 PUT /telephony/${OVH_ROOM_ACCOUNT_NUMBER}/conference/${OVH_ROOM_PHONE_NUMBER}/rooms/*
 GET /telephony/${OVH_ROOM_ACCOUNT_NUMBER}/conference/${OVH_ROOM_PHONE_NUMBER}/roomsStats
+GET /telephony/${OVH_ROOM_ACCOUNT_NUMBER}/conference/${OVH_ROOM_PHONE_NUMBER}/histories
+GET /telephony/${OVH_ROOM_ACCOUNT_NUMBER}/conference/${OVH_ROOM_PHONE_NUMBER}/histories/*
 ```
 
 ## Détail des appels API OVH utilisés

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ Points d'API nécessaires pour les fonctionalités actuelles, pour l'API Rooms :
 POST /telephony/${OVH_ROOM_ACCOUNT_NUMBER}/conference/${OVH_ROOM_PHONE_NUMBER}/rooms
 PUT /telephony/${OVH_ROOM_ACCOUNT_NUMBER}/conference/${OVH_ROOM_PHONE_NUMBER}/rooms/*
 GET /telephony/${OVH_ROOM_ACCOUNT_NUMBER}/conference/${OVH_ROOM_PHONE_NUMBER}/roomsStats
+```
+
+Pour le job qui récupère les stats :
+```
 GET /telephony/${OVH_ROOM_ACCOUNT_NUMBER}/conference/${OVH_ROOM_PHONE_NUMBER}/histories
 GET /telephony/${OVH_ROOM_ACCOUNT_NUMBER}/conference/${OVH_ROOM_PHONE_NUMBER}/histories/*
 ```

--- a/jobs/fetchCallsStats.js
+++ b/jobs/fetchCallsStats.js
@@ -73,6 +73,7 @@ module.exports = async () => {
     console.dir({ summary })
 
     console.debug("End of fetchCallsStats job.")
+    return summary
   } catch(err) {
     console.error("fetchCallsStats job abort on error", err)
     process.exit(1)

--- a/jobs/fetchCallsStats.js
+++ b/jobs/fetchCallsStats.js
@@ -1,18 +1,46 @@
 const conferences = require("../lib/conferences")
 const db = require("../lib/db")
 
+const fetchCallIds = async (phoneNumber) => {
+  const latestRecordedCall = await db.getLastSuccessfulCallStatsJob(phoneNumber)
+  const intervalStartDate = latestRecordedCall ? latestRecordedCall.dateBegin.toISOString() : undefined
+  console.log("Fetching calls for phone number", phoneNumber, "from", intervalStartDate, "to now")
+  const callIds = await conferences.getCallsForPhoneNumber(phoneNumber, intervalStartDate)
+  console.log("Got", callIds.length, "calls")
+  return callIds
+}
+
+const insertCallHistory = async (history, phoneNumber, JOB_DRY_RUN, summary) => {
+  if (JOB_DRY_RUN) {
+    console.log(`${history.id} not inserted, dry run`)
+    summary.insertedRows++
+  } else {
+    const id = await db.insertCallHistory(phoneNumber, history)
+    if (id) {
+      console.log(`${id} inserted`)
+      summary.insertedRows++
+    } else {
+      console.log(`${phoneNumber}_${history.id} already inserted`)
+      summary.alreadyInsertedRows++
+    }
+  }
+}
+
+const recordSuccessfulJob = async (phoneNumber) => {
+  const lastCall = await db.getLatestCallHistory(phoneNumber)
+  await db.insertLastSuccessfulCallStatsJob(phoneNumber, lastCall)
+}
+
 module.exports = async () => {
   console.debug("Start of fetchCallsStats job")
 
   const JOB_DRY_RUN = process.env.JOB_DRY_RUN === "true"
   console.log("Dry run :", JOB_DRY_RUN)
-
   const JOB_CALLS_STATS_SMALL_RUN = process.env.JOB_CALLS_STATS_SMALL_RUN === "true"
   console.log("Small run :", JOB_CALLS_STATS_SMALL_RUN)
 
   const phoneNumbers = await conferences.getAllPhoneNumbers()
   console.log("Got", phoneNumbers.length, "phone numbers.")
-
   if (!phoneNumbers.length) {
     console.log("No numbers found. Check your configuration.")
     process.exit(1)
@@ -30,34 +58,15 @@ module.exports = async () => {
   const numPhoneNumbersToRun = JOB_CALLS_STATS_SMALL_RUN ? 2 : phoneNumbers.length
 
   for (const phoneNumber of sortedPhoneNumbers.slice(0, numPhoneNumbersToRun)) {
-    const latestRecordedCall = await db.getLastSuccessfulCallStatsJob(phoneNumber)
-    const intervalStartDate = latestRecordedCall ? latestRecordedCall.dateBegin.toISOString() : undefined
-
-    console.log("Fetching calls for phone number", phoneNumber, "from", intervalStartDate, "to now")
-    const callIds = await conferences.getCallsForPhoneNumber(phoneNumber, intervalStartDate)
-    console.log("Got", callIds.length, "calls")
+    const callIds = await fetchCallIds(phoneNumber)
 
     for (const callId of callIds) {
       const history = await conferences.getHistoryForCall(phoneNumber, callId)
-
-      if (JOB_DRY_RUN) {
-        console.log(`${history.id} not inserted, dry run`)
-        summary.insertedRows++
-      } else {
-        const id = await db.insertCallHistory(phoneNumber, history)
-        if (id) {
-          console.log(`${id} inserted`)
-          summary.insertedRows++
-        } else {
-          console.log(`${phoneNumber}_${history.id} already inserted`)
-          summary.alreadyInsertedRows++
-        }
-      }
+      await insertCallHistory(history, phoneNumber, JOB_DRY_RUN, summary)
     }
 
     // Record that this batch of inserts was successful
-    const lastCall = await db.getLatestCallHistory(phoneNumber)
-    await db.insertLastSuccessfulCallStatsJob(phoneNumber, lastCall)
+    await recordSuccessfulJob(phoneNumber)
   }
 
   console.dir({ summary })

--- a/jobs/fetchCallsStats.js
+++ b/jobs/fetchCallsStats.js
@@ -10,19 +10,14 @@ const fetchCallIds = async (phoneNumber) => {
   return callIds
 }
 
-const insertCallHistory = async (history, phoneNumber, JOB_DRY_RUN, summary) => {
-  if (JOB_DRY_RUN) {
-    console.log(`${history.id} not inserted, dry run`)
+const insertCallHistory = async (history, phoneNumber, summary) => {
+  const id = await db.insertCallHistory(phoneNumber, history)
+  if (id) {
+    console.log(`${id} inserted`)
     summary.insertedRows++
   } else {
-    const id = await db.insertCallHistory(phoneNumber, history)
-    if (id) {
-      console.log(`${id} inserted`)
-      summary.insertedRows++
-    } else {
-      console.log(`${phoneNumber}_${history.id} already inserted`)
-      summary.alreadyInsertedRows++
-    }
+    console.log(`${phoneNumber}_${history.id} already inserted`)
+    summary.alreadyInsertedRows++
   }
 }
 
@@ -33,9 +28,6 @@ const recordSuccessfulJob = async (phoneNumber) => {
 
 module.exports = async () => {
   console.debug("Start of fetchCallsStats job")
-
-  const JOB_DRY_RUN = process.env.JOB_DRY_RUN === "true"
-  console.log("Dry run :", JOB_DRY_RUN)
 
   try {
     const phoneNumbers = await conferences.getAllPhoneNumbers()
@@ -58,7 +50,7 @@ module.exports = async () => {
 
       for (const callId of callIds) {
         const history = await conferences.getHistoryForCall(phoneNumber, callId)
-        await insertCallHistory(history, phoneNumber, JOB_DRY_RUN, summary)
+        await insertCallHistory(history, phoneNumber, summary)
       }
 
       // Record that this batch of inserts was successful

--- a/jobs/fetchCallsStats.js
+++ b/jobs/fetchCallsStats.js
@@ -30,7 +30,7 @@ module.exports = async () => {
   const numPhoneNumbersToRun = JOB_CALLS_STATS_SMALL_RUN ? 2 : phoneNumbers.length
 
   for (const number of sortedPhoneNumbers.slice(0, numPhoneNumbersToRun)) {
-    const latestRecordedCall = await db.getLastSuccessfullySavedPhoneCall(number)
+    const latestRecordedCall = await db.getLastSuccessfulCallStatsJob(number)
     const intervalStartDate = latestRecordedCall ? latestRecordedCall.dateBegin.toISOString() : undefined
 
     console.log("Fetching calls for phone number", number, "from", intervalStartDate, "to now")
@@ -57,7 +57,7 @@ module.exports = async () => {
 
     // Record that this batch of inserts was successful
     const lastCall = await db.getLatestCallHistory(number)
-    await db.insertLastSuccessfullySavedPhoneCall(number, lastCall)
+    await db.insertLastSuccessfulCallStatsJob(number, lastCall)
   }
 
   console.dir({ summary })

--- a/jobs/fetchCallsStats.js
+++ b/jobs/fetchCallsStats.js
@@ -30,8 +30,12 @@ module.exports = async () => {
   const numPhoneNumbersToRun = JOB_CALLS_STATS_SMALL_RUN ? 2 : phoneNumbers.length
 
   for (const number of sortedPhoneNumbers.slice(0, numPhoneNumbersToRun)) {
-    const callIds = await conferences.getCallsForPhoneNumber(number)
-    console.log("Got", callIds.length, "calls for phone number", number)
+    const latestRecordedCall = await db.getLatestCallHistory(number)
+    const intervalStartDate = latestRecordedCall ? latestRecordedCall.dateBegin.toISOString() : undefined
+
+    console.log("Fetching calls for phone number", number, "from", intervalStartDate, "to now")
+    const callIds = await conferences.getCallsForPhoneNumber(number, intervalStartDate)
+    console.log("Got", callIds.length, "calls")
 
     for (const callId of callIds) {
       const history = await conferences.getHistoryForCall(number, callId)

--- a/jobs/fetchCallsStats.js
+++ b/jobs/fetchCallsStats.js
@@ -30,7 +30,7 @@ module.exports = async () => {
   const numPhoneNumbersToRun = JOB_CALLS_STATS_SMALL_RUN ? 2 : phoneNumbers.length
 
   for (const number of sortedPhoneNumbers.slice(0, numPhoneNumbersToRun)) {
-    const latestRecordedCall = await db.getLatestCallHistory(number)
+    const latestRecordedCall = await db.getLastSuccessfullySavedPhoneCall(number)
     const intervalStartDate = latestRecordedCall ? latestRecordedCall.dateBegin.toISOString() : undefined
 
     console.log("Fetching calls for phone number", number, "from", intervalStartDate, "to now")
@@ -53,8 +53,11 @@ module.exports = async () => {
           summary.alreadyInsertedRows++
         }
       }
-
     }
+
+    // Record that this batch of inserts was successful
+    const lastCall = await db.getLatestCallHistory(number)
+    await db.insertLastSuccessfullySavedPhoneCall(number, lastCall)
   }
 
   console.dir({ summary })

--- a/jobs/fetchCallsStats.js
+++ b/jobs/fetchCallsStats.js
@@ -29,35 +29,35 @@ module.exports = async () => {
 
   const numPhoneNumbersToRun = JOB_CALLS_STATS_SMALL_RUN ? 2 : phoneNumbers.length
 
-  for (const number of sortedPhoneNumbers.slice(0, numPhoneNumbersToRun)) {
-    const latestRecordedCall = await db.getLastSuccessfulCallStatsJob(number)
+  for (const phoneNumber of sortedPhoneNumbers.slice(0, numPhoneNumbersToRun)) {
+    const latestRecordedCall = await db.getLastSuccessfulCallStatsJob(phoneNumber)
     const intervalStartDate = latestRecordedCall ? latestRecordedCall.dateBegin.toISOString() : undefined
 
-    console.log("Fetching calls for phone number", number, "from", intervalStartDate, "to now")
-    const callIds = await conferences.getCallsForPhoneNumber(number, intervalStartDate)
+    console.log("Fetching calls for phone number", phoneNumber, "from", intervalStartDate, "to now")
+    const callIds = await conferences.getCallsForPhoneNumber(phoneNumber, intervalStartDate)
     console.log("Got", callIds.length, "calls")
 
     for (const callId of callIds) {
-      const history = await conferences.getHistoryForCall(number, callId)
+      const history = await conferences.getHistoryForCall(phoneNumber, callId)
 
       if (JOB_DRY_RUN) {
         console.log(`${history.id} not inserted, dry run`)
         summary.insertedRows++
       } else {
-        const id = await db.insertCallHistory(number, history)
+        const id = await db.insertCallHistory(phoneNumber, history)
         if (id) {
           console.log(`${id} inserted`)
           summary.insertedRows++
         } else {
-          console.log(`${number}_${history.id} already inserted`)
+          console.log(`${phoneNumber}_${history.id} already inserted`)
           summary.alreadyInsertedRows++
         }
       }
     }
 
     // Record that this batch of inserts was successful
-    const lastCall = await db.getLatestCallHistory(number)
-    await db.insertLastSuccessfulCallStatsJob(number, lastCall)
+    const lastCall = await db.getLatestCallHistory(phoneNumber)
+    await db.insertLastSuccessfulCallStatsJob(phoneNumber, lastCall)
   }
 
   console.dir({ summary })

--- a/jobs/fetchCallsStats.js
+++ b/jobs/fetchCallsStats.js
@@ -36,8 +36,6 @@ module.exports = async () => {
 
   const JOB_DRY_RUN = process.env.JOB_DRY_RUN === "true"
   console.log("Dry run :", JOB_DRY_RUN)
-  const JOB_CALLS_STATS_SMALL_RUN = process.env.JOB_CALLS_STATS_SMALL_RUN === "true"
-  console.log("Small run :", JOB_CALLS_STATS_SMALL_RUN)
 
   try {
     const phoneNumbers = await conferences.getAllPhoneNumbers()
@@ -53,12 +51,9 @@ module.exports = async () => {
       alreadyInsertedRows: 0,
     }
 
-    // We sort the numbers, so event in "small test", the job will always use the same numbers.
     const sortedPhoneNumbers = phoneNumbers.sort()
 
-    const numPhoneNumbersToRun = JOB_CALLS_STATS_SMALL_RUN ? 2 : phoneNumbers.length
-
-    for (const phoneNumber of sortedPhoneNumbers.slice(0, numPhoneNumbersToRun)) {
+    for (const phoneNumber of sortedPhoneNumbers) {
       const callIds = await fetchCallIds(phoneNumber)
 
       for (const callId of callIds) {

--- a/lib/conferences.js
+++ b/lib/conferences.js
@@ -110,8 +110,9 @@ module.exports.getAllPhoneNumbers = async () => {
   }
 }
 
-module.exports.getCallsForPhoneNumber = async (phoneNumber) => {
-  const url = `/telephony/${config.OVH_ROOM_ACCOUNT_NUMBER}/conference/${phoneNumber}/histories`
+module.exports.getCallsForPhoneNumber = async (phoneNumber, intervalStartDateString) => {
+  const intervalStartParam = intervalStartDateString ? `?dateBegin.from=${intervalStartDateString}` : ""
+  const url = `/telephony/${config.OVH_ROOM_ACCOUNT_NUMBER}/conference/${phoneNumber}/histories${intervalStartParam}`
 
   try {
     return await ovhRooms.requestPromised("GET", url, {})

--- a/lib/db.js
+++ b/lib/db.js
@@ -298,3 +298,40 @@ module.exports.getLatestCallHistory = async (phoneNumber) => {
     throw new Error("Error during getLatestCallHistory")
   }
 }
+
+module.exports.getLastSuccessfullySavedPhoneCall = async (phoneNumber) => {
+  try {
+    const callsArray = await knex("lastSuccessfullySavedPhoneCall")
+      .select("*")
+      .where("phoneNumber", phoneNumber)
+      .limit(1)
+
+    if (callsArray.length > 1) {
+      throw new Error("More than one lastSuccessfullySavedPhoneCall for phoneNumber", phoneNumber)
+    }
+
+    return callsArray[0]
+  } catch (err) {
+    console.error("Error during getLastSuccessfullySavedPhoneCall", err)
+    throw new Error("Error during getLastSuccessfullySavedPhoneCall")
+  }
+}
+
+module.exports.insertLastSuccessfullySavedPhoneCall = async (phoneNumber, callHistory) => {
+  const { id, dateBegin } = callHistory
+
+  try {
+    return (await knex("lastSuccessfullySavedPhoneCall")
+      .insert({
+        id,
+        phoneNumber,
+        dateBegin,
+        updatedAt: new Date().toISOString(),
+      })
+      .onConflict("phoneNumber").merge() // overwrite previous value if present
+      .returning("*")
+      )[0]
+  } catch (err) {
+    console.error("insertLastSuccessfullySavedPhoneCall error", err)
+  }
+}

--- a/lib/db.js
+++ b/lib/db.js
@@ -299,29 +299,29 @@ module.exports.getLatestCallHistory = async (phoneNumber) => {
   }
 }
 
-module.exports.getLastSuccessfullySavedPhoneCall = async (phoneNumber) => {
+module.exports.getLastSuccessfulCallStatsJob = async (phoneNumber) => {
   try {
-    const callsArray = await knex("lastSuccessfullySavedPhoneCall")
+    const callsArray = await knex("lastSuccessfulCallStatsJob")
       .select("*")
       .where("phoneNumber", phoneNumber)
       .limit(1)
 
     if (callsArray.length > 1) {
-      throw new Error("More than one lastSuccessfullySavedPhoneCall for phoneNumber", phoneNumber)
+      throw new Error("More than one lastSuccessfulCallStatsJob for phoneNumber", phoneNumber)
     }
 
     return callsArray[0]
   } catch (err) {
-    console.error("Error during getLastSuccessfullySavedPhoneCall", err)
-    throw new Error("Error during getLastSuccessfullySavedPhoneCall")
+    console.error("Error during getLastSuccessfulCallStatsJob", err)
+    throw new Error("Error during getLastSuccessfulCallStatsJob")
   }
 }
 
-module.exports.insertLastSuccessfullySavedPhoneCall = async (phoneNumber, callHistory) => {
+module.exports.insertLastSuccessfulCallStatsJob = async (phoneNumber, callHistory) => {
   const { id, dateBegin } = callHistory
 
   try {
-    return (await knex("lastSuccessfullySavedPhoneCall")
+    return (await knex("lastSuccessfulCallStatsJob")
       .insert({
         id,
         phoneNumber,
@@ -332,6 +332,6 @@ module.exports.insertLastSuccessfullySavedPhoneCall = async (phoneNumber, callHi
       .returning("*")
       )[0]
   } catch (err) {
-    console.error("insertLastSuccessfullySavedPhoneCall error", err)
+    console.error("insertLastSuccessfulCallStatsJob error", err)
   }
 }

--- a/lib/db.js
+++ b/lib/db.js
@@ -284,3 +284,17 @@ module.exports.insertCallHistory = async (phoneNumber, history) => {
     console.error("insertHistoryInDb error", err)
   }
 }
+
+module.exports.getLatestCallHistory = async (phoneNumber) => {
+  try {
+    return (await knex("phoneCalls")
+      .select("id", "dateBegin")
+      .where("phoneNumber", phoneNumber)
+      .orderBy("dateBegin", "desc")
+      .limit(1))[0]
+
+  } catch (err) {
+    console.error("Error during getLatestCallHistory", err)
+    throw new Error("Error during getLatestCallHistory")
+  }
+}

--- a/migrations/20210611104444_add-last-successful-callsStats-job.js
+++ b/migrations/20210611104444_add-last-successful-callsStats-job.js
@@ -1,6 +1,8 @@
 
 exports.up = function(knex) {
-  return knex.schema.createTable("lastSuccessfullySavedPhoneCall", (table) => {
+  return knex.schema.createTable("lastSuccessfulCallStatsJob", (table) => {
+    // For each fetchCallsStats job that ended successfully, we save the latest phoneCall saved.
+    // The next fetchCallsStats job will start from there.
     table.text("phoneNumber").primary() // Primary because only one lastCall saved per phoneNumber
     table.text("id") // corresponding to id of object in phoneCall table
     table.datetime("dateBegin").notNullable() // duplication but easier to use
@@ -9,5 +11,5 @@ exports.up = function(knex) {
 }
 
 exports.down = function(knex) {
-  return knex.schema.dropTable("lastSuccessfullySavedPhoneCall")
+  return knex.schema.dropTable("lastSuccessfulCallStatsJob")
 }

--- a/migrations/20210611104444_add-last-successfully-saved-phone-call.js
+++ b/migrations/20210611104444_add-last-successfully-saved-phone-call.js
@@ -1,0 +1,13 @@
+
+exports.up = function(knex) {
+  return knex.schema.createTable("lastSuccessfullySavedPhoneCall", (table) => {
+    table.text("phoneNumber").primary() // Primary because only one lastCall saved per phoneNumber
+    table.text("id") // corresponding to id of object in phoneCall table
+    table.datetime("dateBegin").notNullable() // duplication but easier to use
+    table.timestamp("updatedAt")
+  })
+}
+
+exports.down = function(knex) {
+  return knex.schema.dropTable("lastSuccessfullySavedPhoneCall")
+}

--- a/test/fetchCallsStatsTest.js
+++ b/test/fetchCallsStatsTest.js
@@ -1,0 +1,69 @@
+/* global afterEach describe beforeEach it */
+const chai = require("chai")
+const conferences = require("../lib/conferences")
+const knex = require("../knex-client")
+const sinon = require("sinon")
+const utils = require("./utils")
+
+const fetchCallsStats = require("../jobs/fetchCallsStats")
+
+describe("fetchCallsStats", () => {
+  const phoneNumber = "0033122334455"
+  const callId1 = "12345" // todo string or number ?
+  const callId2 = "78901"
+  let getPhoneNumbersStub, getCallsStub, getHistoryForCallStub
+
+  beforeEach(async () => {
+    getPhoneNumbersStub = sinon.stub(conferences, "getAllPhoneNumbers").returns(Promise.resolve([phoneNumber]))
+    getCallsStub = sinon.stub(conferences, "getCallsForPhoneNumber").returns(Promise.resolve([callId1, callId2]))
+
+    getHistoryForCallStub = sinon.stub(conferences, "getHistoryForCall")
+    getHistoryForCallStub.withArgs(phoneNumber, callId1).returns({
+      id: callId1,
+      dateBegin: "2021-06-21T15:23:32.839Z",
+      dateEnd: "2021-06-21T15:33:32.839Z",
+      countParticipants: 2,
+      countConnections: 2,
+      duration : 8888,
+    })
+    getHistoryForCallStub.withArgs(phoneNumber, callId2).returns({
+      id: callId2,
+      dateBegin: "2021-06-20T17:36:32.839Z",
+      dateEnd: "2021-06-20T18:36:32.839Z",
+      countParticipants: 4,
+      countConnections: 5,
+      duration : 777,
+    })
+  })
+
+  afterEach(async () => {
+    await getPhoneNumbersStub.restore()
+    await getCallsStub.restore()
+    await getHistoryForCallStub.restore()
+    await utils.reinitializeDB()
+  })
+
+  it("should fetch call stats", async () => {
+    const summary = await fetchCallsStats()
+
+    chai.assert.equal(summary.phoneNumbersLength, 1)
+    chai.assert.equal(summary.insertedRows, 2)
+
+    // OVH services were called
+    sinon.assert.calledOnce(getPhoneNumbersStub)
+    sinon.assert.calledOnce(getCallsStub)
+    sinon.assert.calledTwice(getHistoryForCallStub)
+
+    // results are saved in DB
+    const savedCalls = await knex("phoneCalls")
+      .select("*")
+      .where("phoneNumber", phoneNumber)
+      .orderBy("dateBegin", "desc")
+
+    chai.assert.lengthOf(savedCalls, 2)
+    chai.assert.include(savedCalls[0].id, callId1, "id of saved history contains callId")
+    chai.assert.include(savedCalls[1].id, callId2, "id of saved history contains callId")
+    chai.assert.include(savedCalls[0].id, phoneNumber, "id of saved history contains phoneNumber")
+    chai.assert.include(savedCalls[1].id, phoneNumber, "id of saved history contains phoneNumber")
+  })
+})

--- a/test/fetchCallsStatsTest.js
+++ b/test/fetchCallsStatsTest.js
@@ -1,6 +1,7 @@
 /* global afterEach describe beforeEach it */
 const chai = require("chai")
 const conferences = require("../lib/conferences")
+const db = require("../lib/db")
 const knex = require("../knex-client")
 const sinon = require("sinon")
 const utils = require("./utils")
@@ -65,5 +66,9 @@ describe("fetchCallsStats", () => {
     chai.assert.include(savedCalls[1].id, callId2, "id of saved history contains callId")
     chai.assert.include(savedCalls[0].id, phoneNumber, "id of saved history contains phoneNumber")
     chai.assert.include(savedCalls[1].id, phoneNumber, "id of saved history contains phoneNumber")
+
+    // Job success is recorded in DB
+    const lastCall = await db.getLatestCallHistory(phoneNumber)
+    chai.assert.equal(lastCall.id, savedCalls[0].id)
   })
 })

--- a/test/fetchCallsStatsTest.js
+++ b/test/fetchCallsStatsTest.js
@@ -87,4 +87,24 @@ describe("fetchCallsStats", () => {
     const lastCall = await db.getLatestCallHistory(phoneNumber)
     chai.assert.equal(lastCall.id, savedCalls[0].id)
   })
+
+  it("should fetch data from beginning of time when there is no previous recorded job", async () => {
+    await fetchCallsStats()
+
+    const noIntervalStartDate = undefined
+    sinon.assert.calledWith(getCallsStub, phoneNumber, noIntervalStartDate)
+  })
+
+  it("should fetch data from last record when there is a previous recorded job", async () => {
+    await fetchCallsStats()
+    // run twice
+    await fetchCallsStats()
+
+    // First run : from beginning of time
+    const noIntervalStartDate = undefined
+    sinon.assert.calledWith(getCallsStub.getCall(0), phoneNumber, noIntervalStartDate)
+    // Second run : from end of previous run
+    const latestCallBeginDate = "2021-06-21T15:23:32.839Z"
+    sinon.assert.calledWith(getCallsStub.getCall(1), phoneNumber, latestCallBeginDate)
+  })
 })


### PR DESCRIPTION
Issue #134 
We were querying for the list of calls since the beginning of time (large number), and then reinserting them.
Instead limit query to get only the calls we don't have yet.