### PR TITLE
Feat/embed metabase stats

### DIFF
--- a/config.js
+++ b/config.js
@@ -96,4 +96,6 @@ config.FEATURE_JOB_CALLS_STATS = process.env.FEATURE_JOB_CALLS_STATS === "true" 
 
 config.ANNOUNCEMENTS = process.env.ANNOUNCEMENTS ? process.env.ANNOUNCEMENTS.split("|") : []
 
+config.STATS_EXTERNAL_DASHBOARD_URL = process.env.STATS_EXTERNAL_DASHBOARD_URL || "https://audioconf-prod-metabase.osc-secnum-fr1.scalingo.io/public/dashboard/0923f77a-b4c9-41ab-b7a0-5c7b1be2b974"
+
 module.exports = config

--- a/config.js
+++ b/config.js
@@ -96,6 +96,6 @@ config.FEATURE_JOB_CALLS_STATS = process.env.FEATURE_JOB_CALLS_STATS === "true" 
 
 config.ANNOUNCEMENTS = process.env.ANNOUNCEMENTS ? process.env.ANNOUNCEMENTS.split("|") : []
 
-config.STATS_EXTERNAL_DASHBOARD_URL = process.env.STATS_EXTERNAL_DASHBOARD_URL || "https://audioconf-prod-metabase.osc-secnum-fr1.scalingo.io/public/dashboard/0923f77a-b4c9-41ab-b7a0-5c7b1be2b974"
+config.STATS_EXTERNAL_DASHBOARD_URL = process.env.STATS_EXTERNAL_DASHBOARD_URL
 
 module.exports = config

--- a/index.js
+++ b/index.js
@@ -108,6 +108,7 @@ if (config.FEATURE_STATS_PAGE) {
     res.render("stats", {
       pageTitle: "Statistiques",
       stats: formattedStats,
+      dashboardUrl: config.STATS_EXTERNAL_DASHBOARD_URL,
     })
   })
 }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -64,3 +64,43 @@ table, th, td {
 th, td {
   padding: 15px;
 }
+
+
+/* XS : de 0 à 575 */
+@media (min-width: 0) {
+  #metabase-stats {
+    height: 4800px;
+  }
+}
+
+/* SM : de 576 à 767 */
+@media (min-width: 576px) {
+  #metabase-stats {
+    height: 6500px;
+  }
+}
+
+/* MD : de 768 à 991  */
+@media (min-width: 768px) {
+  #metabase-stats {
+    height: 6800px;
+  }
+}
+
+/* 803px : metabase layout jumps to desktop. */
+@media (min-width: 803px) {
+  #metabase-stats {
+    height: 1100px;
+  }
+}
+
+/* LG : de 992 à 1247 */
+@media (min-width: 992px) {
+  #metabase-stats {
+    height: 1400px;
+  }
+}
+
+/* XL : >= 1248 */
+@media (min-width: 1248px) {
+}

--- a/static/js/charts.js
+++ b/static/js/charts.js
@@ -108,7 +108,7 @@ window.onload = function() {
       data: data.activeConfsSeries,
     },
   ]
-  const config = makeConfig("Statistiques d'utilisation", data.labels, datasets)
+  const config = makeConfig("Actuellement au téléphone sur une AudioConf", data.labels, datasets)
   drawChart("conf-stats-chart", config)
 
   const datasets2 = [

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -20,7 +20,7 @@
 <div class="fr-container">
   <iframe
       id="metabase-stats"
-      src="https://audioconf-prod-metabase.osc-secnum-fr1.scalingo.io/public/dashboard/0923f77a-b4c9-41ab-b7a0-5c7b1be2b974"
+      src="<%= dashboardUrl %>"
       frameborder="0"
       width="100%"
       allowtransparency>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -36,4 +36,13 @@
   </iframe>
 </div>
 
+<script>
+  window.addEventListener('DOMContentLoaded', function(e) {
+    var theme = localStorage.getItem('scheme'); // theme set by dsfr
+    if (theme === 'dark') {
+      window.document.getElementById('metabase-stats').src = window.document.getElementById('metabase-stats').src + "#theme=night";
+    }
+  });
+</script>
+
 <%- include('partials/footer') -%>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -26,23 +26,25 @@
 
 <script src="static/js/charts.js"></script>
 
-<div class="fr-container">
-  <iframe
-      id="metabase-stats"
-      src="<%= dashboardUrl %>"
-      frameborder="0"
-      width="100%"
-      allowtransparency>
-  </iframe>
-</div>
+<% if(dashboardUrl) {  %>
+  <div class="fr-container">
+    <iframe
+        id="metabase-stats"
+        src="<%= dashboardUrl %>"
+        frameborder="0"
+        width="100%"
+        allowtransparency>
+    </iframe>
+  </div>
 
-<script>
-  window.addEventListener('DOMContentLoaded', function(e) {
-    var theme = localStorage.getItem('scheme'); // theme set by dsfr
-    if (theme === 'dark') {
-      window.document.getElementById('metabase-stats').src = window.document.getElementById('metabase-stats').src + "#theme=night";
-    }
-  });
-</script>
+  <script>
+    window.addEventListener('DOMContentLoaded', function(e) {
+      var theme = localStorage.getItem('scheme'); // theme set by dsfr
+      if (theme === 'dark') {
+        window.document.getElementById('metabase-stats').src = window.document.getElementById('metabase-stats').src + "#theme=night";
+      }
+    });
+  </script>
+<% } %>
 
 <%- include('partials/footer') -%>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -16,4 +16,15 @@
 </div>
 
 <script src="static/js/charts.js"></script>
+
+<div class="fr-container">
+  <iframe
+      id="metabase-stats"
+      src="https://audioconf-prod-metabase.osc-secnum-fr1.scalingo.io/public/dashboard/0923f77a-b4c9-41ab-b7a0-5c7b1be2b974"
+      frameborder="0"
+      width="100%"
+      allowtransparency>
+  </iframe>
+</div>
+
 <%- include('partials/footer') -%>

--- a/views/stats.ejs
+++ b/views/stats.ejs
@@ -1,6 +1,15 @@
 <%- include('partials/header') -%>
 
 <div class="fr-container">
+  <h2>
+    Statistiques d'utilisation
+  </h2>
+  <h3>
+    En temps réel
+  </h3>
+</div>
+
+<div class="fr-container">
   <div class="fr-p-5w">
     <canvas id="conf-stats-chart"></canvas>
   </div>


### PR DESCRIPTION
Add embedded metabase stats in `/stats` page, underneath the home-made live stats.
Use the dark mode option for the embed if the page is in dark mode.