### PR TITLE
Feat : links to faq questions

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ app.locals.format = format
 app.use("/static", express.static("static"))
 app.use("/static/gouvfr", express.static(path.join(__dirname, "node_modules/@gouvfr/dsfr/dist")))
 app.use("/chart.js", express.static(path.join(__dirname, "node_modules/chart.js/dist")))
+app.use("/static/remixicon", express.static(path.join(__dirname, "node_modules/remixicon/fonts")))
 app.use(bodyParser.urlencoded({ extended: false }))
 
 app.use(cookieParser(config.secret))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "conferences",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5854,6 +5854,11 @@
       "requires": {
         "rc": "^1.2.8"
       }
+    },
+    "remixicon": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/remixicon/-/remixicon-2.5.0.tgz",
+      "integrity": "sha512-q54ra2QutYDZpuSnFjmeagmEiN9IMo56/zz5dDNitzKD23oFRw77cWo4TsrAdmdkPiEn8mxlrTqxnkujDbEGww=="
     },
     "repeat-element": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "memorystore": "^1.6.4",
     "nodemailer": "^6.4.14",
     "ovh": "^2.0.3",
-    "pg": "^8.4.2"
+    "pg": "^8.4.2",
+    "remixicon": "^2.5.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/views/faq.ejs
+++ b/views/faq.ejs
@@ -122,7 +122,7 @@
   </div>
 
   <script>
-    function hashHandler() {
+    function openQuestionCorrespondingToHash() {
       const hash = window.location.hash.replace('#', '');
       const question = document.getElementById(hash);
       if (question) {
@@ -131,8 +131,7 @@
       }
     }
 
-    hashHandler();
-    window.addEventListener('hashchange', hashHandler, false);
+    openQuestionCorrespondingToHash();
   </script>
 
   <%- include('partials/footer') -%>

--- a/views/faq.ejs
+++ b/views/faq.ejs
@@ -123,11 +123,11 @@
 
   <script>
     function openQuestionCorrespondingToHash() {
-      const hash = window.location.hash.replace('#', '');
+      const hash = window.location.hash.replace("#", "");
       const question = document.getElementById(hash);
       if (question) {
-        const button = question.getElementsByTagName('button')[0];
-        button.setAttribute('aria-expanded', true);
+        const button = question.getElementsByTagName("button")[0];
+        button.setAttribute("aria-expanded", true);
       }
     }
 

--- a/views/faq.ejs
+++ b/views/faq.ejs
@@ -8,114 +8,101 @@
 
         <ul class="fr-accordions-group">
           <li>
-            <%- include('partials/accordionTop', {
-              title: 'Comment créer une conférence moi-même ?',
-              link: 'comment-creer-une-conference',
+            <%- include("partials/accordionTop", {
+              title: "Comment créer une conférence moi-même ?",
+              link: "comment-creer-une-conference",
               id: 1
             }) -%>
-                <p>
-                  Si vous êtes un <a href="#qui-peut-avoir-acces">agent public de l'État</a>, vous pouvez créer une conférence en toute autonomie.
-                </p>
-                <p>
-                  <ol>
-                    <li>
-                      Allez sur <a href="<%= siteUrl %>">AudioConf</a>.
-                    </li>
-                    <li>
-                      Saisissez votre adresse électronique professionnelle.</li>
-                    <li>
-                      Choisissez la date de votre conférence. Elle sera utilisable toute la journée choisie.
-                    </li>
-                    <li>
-                      Un lien de confirmation est envoyé à votre adresse électronique. Cliquez sur ce lien pour confirmer votre identité.
-                      Le lien est actif 2h.
-                    </li>
-                    <li>
-                      Votre conférence est créée !
-                    </li>
-                    <li>Vous recevez un email récapitulatif contenant les codes. Vous pouvez transmettre ces codes d'accès aux participants de votre conférence.
-                    </li>
-                  </ol>
-                </p>
-                <p>
-                <div class="fr-mb-2w">Vous êtes prêts à faire un essai ?</div>
-                <a class="fr-btn fr-btn fr-btn"
-                  title="Réserver une conférence"
-                  rel="noopener"
-                  href="/">
-                  Réserver une conférence
-                </a>
-                <%- include('partials/accordionBottom') -%>
+              <p>
+                Si vous êtes un <a href="#qui-peut-avoir-acces">agent public de l'État</a>, vous pouvez créer une conférence en toute autonomie.
+              </p>
+              <p>
+                <ol>
+                  <li>
+                    Allez sur <a href="<%= siteUrl %>">AudioConf</a>.
+                  </li>
+                  <li>
+                    Saisissez votre adresse électronique professionnelle.</li>
+                  <li>
+                    Choisissez la date de votre conférence. Elle sera utilisable toute la journée choisie.
+                  </li>
+                  <li>
+                    Un lien de confirmation est envoyé à votre adresse électronique. Cliquez sur ce lien pour confirmer votre identité.
+                    Le lien est actif 2h.
+                  </li>
+                  <li>
+                    Votre conférence est créée !
+                  </li>
+                  <li>Vous recevez un email récapitulatif contenant les codes. Vous pouvez transmettre ces codes d'accès aux participants de votre conférence.
+                  </li>
+                </ol>
+              </p>
+              <div class="fr-mb-2w">Vous êtes prêts à faire un essai ?</div>
+              <a class="fr-btn fr-btn fr-btn"
+                title="Réserver une conférence"
+                rel="noopener"
+                href="/">
+                Réserver une conférence
+              </a>
+            <%- include("partials/accordionBottom") -%>
           </li>
           <li>
-            <section class="fr-accordion" id="comment-rejoindre-une-conference">
-              <h3 class="fr-accordion__title">
-                <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-2">
-                  Comment rejoindre une conférence ?
-                </button>
-              </h3>
-              <div class="fr-collapse" id="accordion-2">
-                <p>
-                  Il faut un téléphone (fixe ou portable) pour rejoindre une conférence AudioConf.
-                </p>
-                <p>
-                  Appelez le numéro que vous a transmis l'organisateur de la conférence, et saisissez le code d'accès
-                  sur le clavier du téléphone, puis appuyez sur #. Vous êtes dans la conférence.
-                </p>
-              </div>
-            </section>
+            <%- include("partials/accordionTop", {
+              title: "Comment rejoindre une conférence ?",
+              link: "comment-rejoindre-une-conference",
+              id: 2
+            }) -%>
+              <p>
+                Il faut un téléphone (fixe ou portable) pour rejoindre une conférence AudioConf.
+              </p>
+              <p>
+                Appelez le numéro que vous a transmis l'organisateur de la conférence, et saisissez le code d'accès
+                sur le clavier du téléphone, puis appuyez sur #. Vous êtes dans la conférence.
+              </p>
+            <%- include("partials/accordionBottom") -%>
           </li>
           <li>
-            <section class="fr-accordion" id="qui-peut-avoir-acces">
-              <h3 class="fr-accordion__title">
-                <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-3">
-                  Qui peut avoir accès à AudioConf ?
-                </button>
-              </h3>
-              <div class="fr-collapse" id="accordion-3">
-                <p>
-                  <b>Seuls les agents de l'État peuvent réserver des conférences</b>. C'est votre email professionnel qui déterminera
-                  si vous avez accès ou non. Les agents des collectivités ne sont pas acceptés.
-                </p>
-                <p>
-                  <b>N'importe qui peut rejoindre une conférence</b> dont il/elle a les codes d'accès, depuis son téléphone.
-                </p>
-                <%- include('partials/askToAddNewService') -%>
-              </div>
-            </section>
+            <%- include("partials/accordionTop", {
+              title: "Qui peut avoir accès à AudioConf ?",
+              link: "qui-peut-avoir-acces",
+              id: 3
+            }) -%>
+              <p>
+                <b>Seuls les agents de l'État peuvent réserver des conférences</b>. C'est votre email professionnel qui déterminera
+                si vous avez accès ou non. Les agents des collectivités ne sont pas acceptés.
+              </p>
+              <p>
+                <b>N'importe qui peut rejoindre une conférence</b> dont il/elle a les codes d'accès, depuis son téléphone.
+              </p>
+              <%- include('partials/askToAddNewService') -%>
+            <%- include("partials/accordionBottom") -%>
           </li>
           <li>
-            <section class="fr-accordion" id="peut-on-rejoindre-une-conference-depuis-l-etranger">
-              <h3 class="fr-accordion__title">
-                <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-4">
-                  Peut-on rejoindre une conférence depuis les DROM ou l'étranger ?
-                </button>
-              </h3>
-              <div class="fr-collapse" id="accordion-4">
-                <p>
-                  Oui. Chaque participant appelle le numéro de téléphone de la conférence :
-                  c'est un numéro situé en France métropolitaine.
-                  L'appel est facturé au prix habituel pour un appel vers la France métropolitaine, il n'est pas surtaxé.
-                  L'appel peut se faire de n'importe quelle région du monde.
-                </p>
-              </div>
-            </section>
+            <%- include("partials/accordionTop", {
+              title: "Peut-on rejoindre une conférence depuis les DROM ou l'étranger ?",
+              link: "peut-on-rejoindre-une-conference-depuis-l-etranger",
+              id: 4
+            }) -%>
+              <p>
+                Oui. Chaque participant appelle le numéro de téléphone de la conférence :
+                c'est un numéro situé en France métropolitaine.
+                L'appel est facturé au prix habituel pour un appel vers la France métropolitaine, il n'est pas surtaxé.
+                L'appel peut se faire de n'importe quelle région du monde.
+              </p>
+            <%- include("partials/accordionBottom") -%>
           </li>
           <li>
-            <section class="fr-accordion" id="comment-annuler-une-conference-reservee">
-              <h3 class="fr-accordion__title">
-                <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-5">
-                  Comment annuler une conférence réservée ?
-                </button>
-              </h3>
-              <div class="fr-collapse" id="accordion-5">
-                <p>
-                  Il n’y a pas besoin d’annuler les conférences non utilisées. Elles ne coûtent pas de ressources.
-                  Si vous avez changé la date de votre réunion, vous pouvez simplement réserver une nouvelle conférence
-                  pour la nouvelle date.
-                </p>
-              </div>
-            </section>
+            <%- include("partials/accordionTop", {
+              title: "Comment annuler une conférence réservée ?",
+              link: "comment-annuler-une-conference-reservee",
+              id: 5
+            }) -%>
+              <p>
+                Il n’y a pas besoin d’annuler les conférences non utilisées. Elles ne coûtent pas de ressources.
+                Si vous avez changé la date de votre réunion, vous pouvez simplement réserver une nouvelle conférence
+                pour la nouvelle date.
+              </p>
+            <%- include("partials/accordionBottom") -%>
           </li>
         </ul>
 

--- a/views/faq.ejs
+++ b/views/faq.ejs
@@ -8,21 +8,11 @@
 
         <ul class="fr-accordions-group">
           <li>
-            <section class="fr-accordion" id="comment-creer-une-conference">
-              <h3 class="fr-accordion__title">
-                <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-1">
-                  <div>
-                    <span>
-                      Comment créer une conférence moi-même ?
-                    </span>
-                    <a href="#comment-creer-une-conference" title="Lien vers cette question">
-                      <span aria-hidden="true" class="ri-link"></span>
-                      <span class="fr-sr-only" rel="noopener noreferrer">Lien vers cette question</span>
-                    </a>
-                  </div>
-                </button>
-              </h3>
-              <div class="fr-collapse" id="accordion-1">
+            <%- include('partials/accordionTop', {
+              title: 'Comment créer une conférence moi-même ?',
+              link: 'comment-creer-une-conference',
+              id: 1
+            }) -%>
                 <p>
                   Si vous êtes un <a href="#qui-peut-avoir-acces">agent public de l'État</a>, vous pouvez créer une conférence en toute autonomie.
                 </p>
@@ -55,8 +45,7 @@
                   href="/">
                   Réserver une conférence
                 </a>
-              </div>
-            </section>
+                <%- include('partials/accordionBottom') -%>
           </li>
           <li>
             <section class="fr-accordion" id="comment-rejoindre-une-conference">

--- a/views/faq.ejs
+++ b/views/faq.ejs
@@ -6,105 +6,103 @@
       <div class="fr-col">
         <h2 class="fr-mt-7w">Questions fréquentes</h2>
 
-        <ul class="fr-accordions-group">
-          <li>
-            <%- include("partials/accordionTop", {
-              title: "Comment créer une conférence moi-même ?",
-              link: "comment-creer-une-conference",
-              id: 1
-            }) -%>
-              <p>
-                Si vous êtes un <a href="#qui-peut-avoir-acces">agent public de l'État</a>, vous pouvez créer une conférence en toute autonomie.
-              </p>
-              <p>
-                <ol>
-                  <li>
-                    Allez sur <a href="<%= siteUrl %>">AudioConf</a>.
-                  </li>
-                  <li>
-                    Saisissez votre adresse électronique professionnelle.</li>
-                  <li>
-                    Choisissez la date de votre conférence. Elle sera utilisable toute la journée choisie.
-                  </li>
-                  <li>
-                    Un lien de confirmation est envoyé à votre adresse électronique. Cliquez sur ce lien pour confirmer votre identité.
-                    Le lien est actif 2h.
-                  </li>
-                  <li>
-                    Votre conférence est créée !
-                  </li>
-                  <li>Vous recevez un email récapitulatif contenant les codes. Vous pouvez transmettre ces codes d'accès aux participants de votre conférence.
-                  </li>
-                </ol>
-              </p>
-              <div class="fr-mb-2w">Vous êtes prêts à faire un essai ?</div>
-              <a class="fr-btn fr-btn fr-btn"
-                title="Réserver une conférence"
-                rel="noopener"
-                href="/">
-                Réserver une conférence
-              </a>
-            <%- include("partials/accordionBottom") -%>
-          </li>
-          <li>
-            <%- include("partials/accordionTop", {
-              title: "Comment rejoindre une conférence ?",
-              link: "comment-rejoindre-une-conference",
-              id: 2
-            }) -%>
-              <p>
-                Il faut un téléphone (fixe ou portable) pour rejoindre une conférence AudioConf.
-              </p>
-              <p>
-                Appelez le numéro que vous a transmis l'organisateur de la conférence, et saisissez le code d'accès
-                sur le clavier du téléphone, puis appuyez sur #. Vous êtes dans la conférence.
-              </p>
-            <%- include("partials/accordionBottom") -%>
-          </li>
-          <li>
-            <%- include("partials/accordionTop", {
-              title: "Qui peut avoir accès à AudioConf ?",
-              link: "qui-peut-avoir-acces",
-              id: 3
-            }) -%>
-              <p>
-                <b>Seuls les agents de l'État peuvent réserver des conférences</b>. C'est votre email professionnel qui déterminera
-                si vous avez accès ou non. Les agents des collectivités ne sont pas acceptés.
-              </p>
-              <p>
-                <b>N'importe qui peut rejoindre une conférence</b> dont il/elle a les codes d'accès, depuis son téléphone.
-              </p>
-              <%- include('partials/askToAddNewService') -%>
-            <%- include("partials/accordionBottom") -%>
-          </li>
-          <li>
-            <%- include("partials/accordionTop", {
-              title: "Peut-on rejoindre une conférence depuis les DROM ou l'étranger ?",
-              link: "peut-on-rejoindre-une-conference-depuis-l-etranger",
-              id: 4
-            }) -%>
-              <p>
-                Oui. Chaque participant appelle le numéro de téléphone de la conférence :
-                c'est un numéro situé en France métropolitaine.
-                L'appel est facturé au prix habituel pour un appel vers la France métropolitaine, il n'est pas surtaxé.
-                L'appel peut se faire de n'importe quelle région du monde.
-              </p>
-            <%- include("partials/accordionBottom") -%>
-          </li>
-          <li>
-            <%- include("partials/accordionTop", {
-              title: "Comment annuler une conférence réservée ?",
-              link: "comment-annuler-une-conference-reservee",
-              id: 5
-            }) -%>
-              <p>
-                Il n’y a pas besoin d’annuler les conférences non utilisées. Elles ne coûtent pas de ressources.
-                Si vous avez changé la date de votre réunion, vous pouvez simplement réserver une nouvelle conférence
-                pour la nouvelle date.
-              </p>
-            <%- include("partials/accordionBottom") -%>
-          </li>
-        </ul>
+        <div>
+          <%- include("partials/accordionTop", {
+            title: "Comment créer une conférence moi-même ?",
+            link: "comment-creer-une-conference",
+            id: 1
+          }) -%>
+            <p>
+              Si vous êtes un <a href="#qui-peut-avoir-acces">agent public de l'État</a>, vous pouvez créer une conférence en toute autonomie.
+            </p>
+            <p>
+              <ol>
+                <li>
+                  Allez sur <a href="<%= siteUrl %>">AudioConf</a>.
+                </li>
+                <li>
+                  Saisissez votre adresse électronique professionnelle.</li>
+                <li>
+                  Choisissez la date de votre conférence. Elle sera utilisable toute la journée choisie.
+                </li>
+                <li>
+                  Un lien de confirmation est envoyé à votre adresse électronique. Cliquez sur ce lien pour confirmer votre identité.
+                  Le lien est actif 2h.
+                </li>
+                <li>
+                  Votre conférence est créée !
+                </li>
+                <li>Vous recevez un email récapitulatif contenant les codes. Vous pouvez transmettre ces codes d'accès aux participants de votre conférence.
+                </li>
+              </ol>
+            </p>
+            <div class="fr-mb-2w">Vous êtes prêts à faire un essai ?</div>
+            <a class="fr-btn fr-btn fr-btn"
+              title="Réserver une conférence"
+              rel="noopener"
+              href="/">
+              Réserver une conférence
+            </a>
+          <%- include("partials/accordionBottom") -%>
+        </div>
+        <div>
+          <%- include("partials/accordionTop", {
+            title: "Comment rejoindre une conférence ?",
+            link: "comment-rejoindre-une-conference",
+            id: 2
+          }) -%>
+            <p>
+              Il faut un téléphone (fixe ou portable) pour rejoindre une conférence AudioConf.
+            </p>
+            <p>
+              Appelez le numéro que vous a transmis l'organisateur de la conférence, et saisissez le code d'accès
+              sur le clavier du téléphone, puis appuyez sur #. Vous êtes dans la conférence.
+            </p>
+          <%- include("partials/accordionBottom") -%>
+        </div>
+        <div>
+          <%- include("partials/accordionTop", {
+            title: "Qui peut avoir accès à AudioConf ?",
+            link: "qui-peut-avoir-acces",
+            id: 3
+          }) -%>
+            <p>
+              <b>Seuls les agents de l'État peuvent réserver des conférences</b>. C'est votre email professionnel qui déterminera
+              si vous avez accès ou non. Les agents des collectivités ne sont pas acceptés.
+            </p>
+            <p>
+              <b>N'importe qui peut rejoindre une conférence</b> dont il/elle a les codes d'accès, depuis son téléphone.
+            </p>
+            <%- include('partials/askToAddNewService') -%>
+          <%- include("partials/accordionBottom") -%>
+        </div>
+        <div>
+          <%- include("partials/accordionTop", {
+            title: "Peut-on rejoindre une conférence depuis les DROM ou l'étranger ?",
+            link: "peut-on-rejoindre-une-conference-depuis-l-etranger",
+            id: 4
+          }) -%>
+            <p>
+              Oui. Chaque participant appelle le numéro de téléphone de la conférence :
+              c'est un numéro situé en France métropolitaine.
+              L'appel est facturé au prix habituel pour un appel vers la France métropolitaine, il n'est pas surtaxé.
+              L'appel peut se faire de n'importe quelle région du monde.
+            </p>
+          <%- include("partials/accordionBottom") -%>
+        </div>
+        <div>
+          <%- include("partials/accordionTop", {
+            title: "Comment annuler une conférence réservée ?",
+            link: "comment-annuler-une-conference-reservee",
+            id: 5
+          }) -%>
+            <p>
+              Il n’y a pas besoin d’annuler les conférences non utilisées. Elles ne coûtent pas de ressources.
+              Si vous avez changé la date de votre réunion, vous pouvez simplement réserver une nouvelle conférence
+              pour la nouvelle date.
+            </p>
+          <%- include("partials/accordionBottom") -%>
+        </div>
 
         <div class="fr-callout fr-my-3w">
           <h2 class="fr-callout__title"> Vous n'avez pas trouvé la réponse à votre question ? </h2>

--- a/views/faq.ejs
+++ b/views/faq.ejs
@@ -11,7 +11,15 @@
             <section class="fr-accordion" id="comment-creer-une-conference">
               <h3 class="fr-accordion__title">
                 <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-1">
-                  Comment créer une conférence moi-même ?
+                  <div>
+                    <span>
+                      Comment créer une conférence moi-même ?
+                    </span>
+                    <a href="#comment-creer-une-conference" title="Lien vers cette question">
+                      <span aria-hidden="true" class="ri-link"></span>
+                      <span class="fr-sr-only" rel="noopener noreferrer">Lien vers cette question</span>
+                    </a>
+                  </div>
                 </button>
               </h3>
               <div class="fr-collapse" id="accordion-1">

--- a/views/partials/accordionBottom.ejs
+++ b/views/partials/accordionBottom.ejs
@@ -1,0 +1,2 @@
+</div>
+</section>

--- a/views/partials/accordionTop.ejs
+++ b/views/partials/accordionTop.ejs
@@ -1,0 +1,15 @@
+<section class="fr-accordion" id="<%= link %>">
+  <h3 class="fr-accordion__title">
+    <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-<%= id %>">
+      <div>
+        <span>
+          <%= title %>
+        </span>
+        <a href="#<%= link %>" title="Lien vers cette question">
+          <span aria-hidden="true" class="ri-link"></span>
+          <span class="fr-sr-only" rel="noopener noreferrer">Lien vers cette question</span>
+        </a>
+      </div>
+    </button>
+  </h3>
+  <div class="fr-collapse" id="accordion-<%= id %>">

--- a/views/partials/accordionTop.ejs
+++ b/views/partials/accordionTop.ejs
@@ -9,10 +9,10 @@
   <script>
     // When the title of the accordion is clicked, set the hash to the corresponding question id.
     (function () {
-      var scripts = document.getElementsByTagName('script');
+      var scripts = document.getElementsByTagName("script");
       var currentScript = scripts[scripts.length - 1];
       var accordion = currentScript.parentElement.parentElement;
-      var button = accordion.getElementsByTagName('button')[0]
+      var button = accordion.getElementsByTagName("button")[0];
       button.addEventListener("click", function() {
         if (history.pushState) {
           history.pushState(null, null, "#" + accordion.id);

--- a/views/partials/accordionTop.ejs
+++ b/views/partials/accordionTop.ejs
@@ -1,15 +1,25 @@
 <section class="fr-accordion" id="<%= link %>">
   <h3 class="fr-accordion__title">
     <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-<%= id %>">
-      <div>
-        <span>
-          <%= title %>
-        </span>
-        <a href="#<%= link %>" title="Lien vers cette question">
-          <span aria-hidden="true" class="ri-link"></span>
-          <span class="fr-sr-only" rel="noopener noreferrer">Lien vers cette question</span>
-        </a>
-      </div>
+      <%= title %>
     </button>
   </h3>
   <div class="fr-collapse" id="accordion-<%= id %>">
+
+  <script>
+    // When the title of the accordion is clicked, set the hash to the corresponding question id.
+    (function () {
+      var scripts = document.getElementsByTagName('script');
+      var currentScript = scripts[scripts.length - 1];
+      var accordion = currentScript.parentElement.parentElement;
+      var button = accordion.getElementsByTagName('button')[0]
+      button.addEventListener("click", function() {
+        if (history.pushState) {
+          history.pushState(null, null, "#" + accordion.id);
+        }
+        else { // fallback for old browsers. The window will jump.
+          location.hash = "#" + accordion.id;
+        }
+      });
+    })();
+  </script>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -14,6 +14,7 @@
   <!-- todo(estellecomment) : import min css and js -->
   <link rel="stylesheet" type="text/css" href="/static/gouvfr/css/dsfr.min.css">
   <link rel="stylesheet" href="/static/css/custom.css">
+  <link rel="stylesheet" href="/static/remixicon/remixicon.css">
   <link rel="icon" type="image/png" sizes="16x16" href="/static/images/favicon/favicon-16x16.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon/favicon-32x32.png">
 </head>


### PR DESCRIPTION
When a question is clicked, the hash changes.

Ex : I click "Comment créer une conférence ?"
![image](https://user-images.githubusercontent.com/911434/124282204-ddca0800-db4a-11eb-92ce-ddb38d73801b.png)

This can be used to share URLs to a specific question. The page will open at the right question.

Includes a refactor to use partials for questions. (no change to question text)