### PR TITLE
Remove lint errors in tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,8 @@
         "browser": true,
         "commonjs": true,
         "es2021": true,
-        "node": true
+        "node": true,
+        "mocha": true
     },
     "extends": [
         // Uncomment to have full code style fix


### PR DESCRIPTION
Tell eslint we are using mocha. Otherwise all the "describe" are shown as unknown functions.
