### PR TITLE
Changement email de sondage

### DIFF
--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -181,7 +181,7 @@ module.exports.sendSurveyEmail = async function (toEmail) {
   const html = `
   <p>Bonjour,</p>
   <p></p>
-  <p>Avez-vous apprécié <b>${config.APP_NAME}</b> ?</p>
+  <p>Votre réservation de numéro de conférence <b>${config.APP_NAME}</b> c'est terminé hier.<br>Avez-vous apprécié le service ?</p>
 
   <p>Avez-vous eu des difficultés qui vous ont irrité ?</p>
 
@@ -194,7 +194,7 @@ module.exports.sendSurveyEmail = async function (toEmail) {
     href="${config.AFTER_MEETING_SURVEY_URL}">
       Donnez votre avis
   </a>
-  (Certains services informatiques bloquent l'outil de sondage, dans ce cas, vous pouvez nous faire un retour en répondant à cet email)
+  (Si votre service informatique bloque l'outil de sondage, dans ce cas, vous pouvez nous faire un retour en répondant à cet email)
 
   <p>À bientôt,</p>
 


### PR DESCRIPTION
## Problème
L'utilisateur ne sait plus que son numéro de conférence de X jours a expiré

## Solution
Rappeler qu'un numéro de conférence a expiré dans le message du sondage

## Note
Rappeler le nom ou la durée de reservation pourrait aider à savoir de quel numéro on parle pour ceux qui en ont plusieurs en cours.